### PR TITLE
Use numeric stable version of sigmoid function in WoE model

### DIFF
--- a/src/molusce/algorithms/models/woe/manager.py
+++ b/src/molusce/algorithms/models/woe/manager.py
@@ -11,6 +11,16 @@ from .model import woe
 
 
 def sigmoid(x):
+    """Sigmoid function."""
+
+    # Large absolute value of x causes overflows in Exp function.
+    # To prevent in we truncate x: the result is almost the same (0 or 1),
+    # This is simple approach, but it works ))
+    # Numericaly stable implementation of sigmoid see:
+    # https://stackoverflow.com/a/64717799
+    limit_val = 100
+    
+    x = np.maximum(-limit_val, np.minimum(x, limit_val))
     return 1 / (1 + np.exp(-x))
 
 


### PR DESCRIPTION
Sigmoid function uses Exp(X), it can return Inf in case of big values of X. This causes errors for next computation steps. So I use truncated X to prevent numeric overflow.