### PR TITLE
Comment out unused code

### DIFF
--- a/src/molusce/algorithms/models/mlp/model.py
+++ b/src/molusce/algorithms/models/mlp/model.py
@@ -102,75 +102,77 @@ class MLP:
 
 
 # -----------------------------------------------------------------------------
-if __name__ == "__main__":
-    import matplotlib.pyplot as plt
 
-    def learn(network, samples, epochs=2500, lrate=0.1, momentum=0.1):
-        # Train
-        for _i in range(epochs):
-            n = np.random.randint(samples.size)
-            network.propagate_forward(samples["input"][n])
-            network.propagate_backward(samples["output"][n], lrate, momentum)
-        # Test
-        for i in range(samples.size):
-            o = network.propagate_forward(samples["input"][i])
-            print(i, samples["input"][i], f"{o[0]:.2f}", end=" ")
-            print(f"(expected {samples["output"][i]:.2f})")
-        print()
-
-    network = MLP(2, 2, 1)
-    samples = np.zeros(4, dtype=[("input", float, 2), ("output", float, 1)])
-
-    # Example 1 : OR logical function
-    # -------------------------------------------------------------------------
-    print("Learning the OR logical function")
-    network.reset()
-    samples[0] = (0, 0), 0
-    samples[1] = (1, 0), 1
-    samples[2] = (0, 1), 1
-    samples[3] = (1, 1), 1
-    learn(network, samples)
-
-    # Example 2 : AND logical function
-    # -------------------------------------------------------------------------
-    print("Learning the AND logical function")
-    network.reset()
-    samples[0] = (0, 0), 0
-    samples[1] = (1, 0), 0
-    samples[2] = (0, 1), 0
-    samples[3] = (1, 1), 1
-    learn(network, samples)
-
-    # Example 3 : XOR logical function
-    # -------------------------------------------------------------------------
-    print("Learning the XOR logical function")
-    network.reset()
-    samples[0] = (0, 0), 0
-    samples[1] = (1, 0), 1
-    samples[2] = (0, 1), 1
-    samples[3] = (1, 1), 0
-    learn(network, samples)
-
-    # Example 4 : Learning sin(x)
-    # -------------------------------------------------------------------------
-    print("Learning the sin function")
-    network = MLP(1, 7, 1)
-    samples = np.zeros(500, dtype=[("x", float, 1), ("y", float, 1)])
-    samples["x"] = np.linspace(0, 1, 500)
-    samples["y"] = np.sin(samples["x"] * np.pi)
-
-    for _i in range(10000):
-        n = np.random.randint(samples.size)
-        network.propagate_forward(samples["x"][n])
-        network.propagate_backward(samples["y"][n])
-
-    plt.figure(figsize=(10, 5))
-    # Draw real function
-    x, y = samples["x"], samples["y"]
-    plt.plot(x, y, color="b", lw=1)
-    # Draw network approximated function
-    for i in range(samples.shape[0]):
-        y[i] = network.propagate_forward(x[i])
-    plt.plot(x, y, color="r", lw=3)
-    plt.axis([0, 1, 0, 1])
-    plt.show()
+# if __name__ == "__main__":
+#     import matplotlib.pyplot as plt
+# 
+#     def learn(network, samples, epochs=2500, lrate=0.1, momentum=0.1):
+#         # Train
+#         for _i in range(epochs):
+#             n = np.random.randint(samples.size)
+#             network.propagate_forward(samples["input"][n])
+#             network.propagate_backward(samples["output"][n], lrate, momentum)
+#         # Test
+#         for i in range(samples.size):
+#             o = network.propagate_forward(samples["input"][i])
+#             print(i, samples["input"][i], f"{o[0]:.2f}", end=" ")
+#             print(f"(expected {samples["output"][i]:.2f})")
+#         print()
+# 
+#     network = MLP(2, 2, 1)
+#     samples = np.zeros(4, dtype=[("input", float, 2), ("output", float, 1)])
+# 
+#     # Example 1 : OR logical function
+#     # -------------------------------------------------------------------------
+#     print("Learning the OR logical function")
+#     network.reset()
+#     samples[0] = (0, 0), 0
+#     samples[1] = (1, 0), 1
+#     samples[2] = (0, 1), 1
+#     samples[3] = (1, 1), 1
+#     learn(network, samples)
+# 
+#     # Example 2 : AND logical function
+#     # -------------------------------------------------------------------------
+#     print("Learning the AND logical function")
+#     network.reset()
+#     samples[0] = (0, 0), 0
+#     samples[1] = (1, 0), 0
+#     samples[2] = (0, 1), 0
+#     samples[3] = (1, 1), 1
+#     learn(network, samples)
+# 
+#     # Example 3 : XOR logical function
+#     # -------------------------------------------------------------------------
+#     print("Learning the XOR logical function")
+#     network.reset()
+#     samples[0] = (0, 0), 0
+#     samples[1] = (1, 0), 1
+#     samples[2] = (0, 1), 1
+#     samples[3] = (1, 1), 0
+#     learn(network, samples)
+# 
+#     # Example 4 : Learning sin(x)
+#     # -------------------------------------------------------------------------
+#     print("Learning the sin function")
+#     network = MLP(1, 7, 1)
+#     samples = np.zeros(500, dtype=[("x", float, 1), ("y", float, 1)])
+#     samples["x"] = np.linspace(0, 1, 500)
+#     samples["y"] = np.sin(samples["x"] * np.pi)
+# 
+#     for _i in range(10000):
+#         n = np.random.randint(samples.size)
+#         network.propagate_forward(samples["x"][n])
+#         network.propagate_backward(samples["y"][n])
+# 
+#     plt.figure(figsize=(10, 5))
+#     # Draw real function
+#     x, y = samples["x"], samples["y"]
+#     plt.plot(x, y, color="b", lw=1)
+#     # Draw network approximated function
+#     for i in range(samples.shape[0]):
+#         y[i] = network.propagate_forward(x[i])
+#     plt.plot(x, y, color="r", lw=3)
+#     plt.axis([0, 1, 0, 1])
+#     plt.show()
+# 


### PR DESCRIPTION
1. This part of the module is not used in the plugin (it contains example of MLP using).
2. The code has syntax error (at least for my version of Python):
```
    File "/home/dmitry/.local/share/QGIS/QGIS3/profiles/default/python/plugins/qgis_molusce/src/molusce/algorithms/models/mlp/model.py", line 118
    print(f"(expected {samples["output"][i]:.2f})")
                                ^^^^^^
SyntaxError: f-string: unmatched '['
```
The error can be fixed by `'` quote marks instead of `"` , but the code is unnecessary for the plugin.
So I commented unused code.