### PR TITLE
Increase MAX_CATEGORIES to 256

### DIFF
--- a/src/molusce/algorithms/dataprovider.py
+++ b/src/molusce/algorithms/dataprovider.py
@@ -7,7 +7,7 @@ from osgeo import gdal, osr
 from .utils import binaryzation, get_gradations
 
 # If a raster band has more then MAX_CATEGORIES categories, we think that the band contains continues values
-MAX_CATEGORIES = 99
+MAX_CATEGORIES = 256
 
 
 class ProviderError(Exception):


### PR DESCRIPTION
There are global LULC datasets with more than 99 classes
e.g. https://storage.googleapis.com/earthenginepartners-hansen/GLCLU2000-2020/v2/download.html

256 looks like more universal limit