### PR TITLE
Different spatial variables versions support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "molusce"
-version = "4.2.1"
+version = "4.3.0"
 readme = "README.md"
 license = { file = "LICENSE" }
 

--- a/src/molusce/algorithms/dataprovider.py
+++ b/src/molusce/algorithms/dataprovider.py
@@ -168,7 +168,7 @@ class Raster:
     def getBand(self, bandNo):
         return self.bands[bandNo - 1]
 
-    def getBandsCount(self):
+    def getBandsCount(self) -> int:
         return self.bandcount
 
     def getBandGradation(self, bandNo):

--- a/src/molusce/algorithms/models/simulator/sim.py
+++ b/src/molusce/algorithms/models/simulator/sim.py
@@ -10,7 +10,7 @@ class Simulator(QObject):
     over a number of cycles
     """
 
-    rangeChanged = pyqtSignal(str, int)
+    rangeChanged = pyqtSignal(str, int) 
     updateProgress = pyqtSignal()
     simFinished = pyqtSignal()
     logMessage = pyqtSignal(str)

--- a/src/molusce/i18n/molusce_es.ts
+++ b/src/molusce/i18n/molusce_es.ts
@@ -404,551 +404,606 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MolusceDialog</name>
     <message>
-        <location filename="../moluscedialog.py" line="176"/>
+        <location filename="../moluscedialog.py" line="184"/>
         <source>Start logging</source>
         <translation>Empezar a registrar</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Missed selected row</source>
         <translation>Objeto no seleccionado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="224"/>
+        <location filename="../moluscedialog.py" line="232"/>
         <source>Initial raster is not selected. Please specify input data and try again</source>
         <translation>La raster de estados iniciales no está configurada. Por favor, especifique los datos de entrada e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="363"/>
+        <location filename="../moluscedialog.py" line="431"/>
         <source>Memory Error occurred (loading raster %s). Perhaps the system is low on memory.</source>
         <translation>Se ha producido un error de memoria (cargando imagen %s). Puede que no haya suficiente memoria en el sistema.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="278"/>
+        <location filename="../moluscedialog.py" line="286"/>
         <source>Final raster is not selected. Please specify input data and try again</source>
         <translation>No se ha especificado la raster de estado final. Por favor, especifique los datos de entrada e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="296"/>
+        <location filename="../moluscedialog.py" line="304"/>
         <source>Set final layer to %s</source>
         <translation>Establecer raster de estado final a %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="326"/>
+        <location filename="../moluscedialog.py" line="394"/>
         <source>Factor raster is not selected. Please specify input data and try again</source>
         <translation>El mapa de influencia del factor no está configurado. Especifique los datos de entrada e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="361"/>
+        <location filename="../moluscedialog.py" line="369"/>
         <source>Added factor layer %s</source>
         <translation>Mapa de influencia del factor añadido - %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error</source>
         <translation>Error de memoria</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error occurred. Perhaps the system is low on memory.</source>
         <translation>Se ha producido un error de memoria. Puede que no haya suficiente memoria en el sistema.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="413"/>
+        <location filename="../moluscedialog.py" line="480"/>
         <source>Removed factor layer %s</source>
         <translation>Mapa de influencia del factor eliminado - %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="427"/>
+        <location filename="../moluscedialog.py" line="527"/>
         <source>Factors list cleared</source>
         <translation>Se ha depurado la lista de factores de influencia</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Missed input data</source>
         <translation>No hay datos de entrada</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="772"/>
+        <location filename="../moluscedialog.py" line="964"/>
         <source>Factors rasters is not set. Please specify them and try again</source>
         <translation>No se han especificado mapas de influencia de factores. Por favor, especifique los mapas de influencia de los factores e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="548"/>
+        <location filename="../moluscedialog.py" line="716"/>
         <source>Initial or final raster is not set. Please specify input data and try again</source>
         <translation>No se ha especificado ninguna raster de estados inicial o final. Por favor, especifique los datos de entrada e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Different geometry</source>
         <translation>Características espaciales no coincidentes</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="461"/>
+        <location filename="../moluscedialog.py" line="573"/>
         <source>Geometries of the initial raster and final raster are different!</source>
         <translation>Las características espaciales de los rásteres de estado inicial y final no coinciden!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometry is matched</source>
         <translation>Las características espaciales coinciden</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometries of the rasters are matched!</source>
         <translation>Las características espaciales de los rásteres coinciden!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="493"/>
+        <location filename="../moluscedialog.py" line="661"/>
         <source>Memory Error occurred (correlation checking). Perhaps the system is low on memory.</source>
         <translation>Se ha producido un error de memoria (cálculo de correlación). Puede que no haya memoria suficiente en el sistema.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="542"/>
+        <location filename="../moluscedialog.py" line="710"/>
         <source>Class statistics and transition matrix are updated</source>
         <translation>Tabla de estadísticas por clases y matriz de transición actualizadas</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="557"/>
+        <location filename="../moluscedialog.py" line="725"/>
         <source>Save change map</source>
         <translation>Guardar el mapa de cambios</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</source>
         <translation>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1152"/>
+        <location filename="../moluscedialog.py" line="1346"/>
         <source>No file selected</source>
         <translation>Fichero no seleccionado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="615"/>
+        <location filename="../moluscedialog.py" line="783"/>
         <source>Change Map is created</source>
         <translation>Se ha creado un mapa de cambios</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Initial raster is not set. Please specify it and try again</source>
         <translation>No se ha especificado el raster de estados iniciales. Por favor, especifique la raster de estados iniciales e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="632"/>
+        <location filename="../moluscedialog.py" line="800"/>
         <source>Prefix of transition potential maps is not set. Please specify it and try again</source>
         <translation>No se ha especificado el prefijo del fichero para los mapas de potencial de transición. Por favor, especifique un prefijo e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Missed model</source>
         <translation>Modelo no especificado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Missed transition matrix</source>
         <translation>Matriz de transición no calculada</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Please calculate transition matrix and try again</source>
         <translation>Por favor, calcule la matriz de transición e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="816"/>
+        <location filename="../moluscedialog.py" line="1010"/>
         <source>Simulation process is started</source>
         <translation>Proceso de simulación iniciado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="852"/>
+        <location filename="../moluscedialog.py" line="1046"/>
         <source>Output path for risk function map is not set. Skipping this step</source>
         <translation>No se ha establecido ninguna ruta de guardado para el mapa de confianza de la previsión. Si se omite este paso</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="902"/>
+        <location filename="../moluscedialog.py" line="1096"/>
         <source>Output path for simulated risk map is not set. Skipping this step</source>
         <translation>No se ha establecido la ruta de guardado para el mapa de previsión de cambios. Si se omite este paso</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Not implemented yet</source>
         <translation>Mapas de potencial de transición no implementados</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Transition potentials not implemented yet for the model.</source>
         <translation>Los mapas de potencial de transición para este modelo aún no se han implementado.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="943"/>
+        <location filename="../moluscedialog.py" line="1137"/>
         <source>Simulation process is finished</source>
         <translation>El proceso de simulación ha finalizado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file</source>
         <translation>No se puede leer el fichero</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="988"/>
+        <location filename="../moluscedialog.py" line="1182"/>
         <source>Validation process is started</source>
         <translation>Inicio del proceso de validación</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1030"/>
+        <location filename="../moluscedialog.py" line="1224"/>
         <source>Validation process is finished</source>
         <translation>Proceso de validación completado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable</source>
         <translation>El cálculo del estadístico kappa no es aplicable</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1092"/>
+        <location filename="../moluscedialog.py" line="1286"/>
         <source>Kappa validation process is started</source>
         <translation>Se ha puesto en marcha el proceso de cálculo de las estadísticas kappa</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1111"/>
+        <location filename="../moluscedialog.py" line="1305"/>
         <source>Kappa validation process is finished</source>
         <translation>Se ha completado el proceso de cálculo del estadístico kappa</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1144"/>
+        <location filename="../moluscedialog.py" line="1338"/>
         <source>Save validation map</source>
         <translation>Guardar mapa de validación</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1202"/>
+        <location filename="../moluscedialog.py" line="1396"/>
         <source>Process of Validation Map creating is started</source>
         <translation>Se inicia el proceso de creación del mapa de validación</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1486"/>
+        <location filename="../moluscedialog.py" line="1681"/>
         <source>Pearson&apos;s Correlation</source>
         <translation>Coeficiente de correlación de Pearson</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1496"/>
+        <location filename="../moluscedialog.py" line="1691"/>
         <source>Cramer&apos;s Coefficient</source>
         <translation>Coeficiente de Cramer</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1511"/>
+        <location filename="../moluscedialog.py" line="1706"/>
         <source>Joint Information Uncertainty</source>
         <translation>Coeficiente JIU (incertidumbre de información general)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1282"/>
+        <location filename="../moluscedialog.py" line="1477"/>
         <source>raster units</source>
         <translation>unidades de raster</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1547"/>
+        <location filename="../moluscedialog.py" line="1742"/>
         <source>sq. km.</source>
         <translation>cuadrados km</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1549"/>
+        <location filename="../moluscedialog.py" line="1744"/>
         <source>ha</source>
         <translation>hectáreas</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1700"/>
+        <location filename="../moluscedialog.py" line="1895"/>
         <source>Artificial Neural Network (Multi-layer Perceptron)</source>
         <translation>Redes neuronales (perceptrón multicapa)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1705"/>
+        <location filename="../moluscedialog.py" line="1900"/>
         <source>Weights of Evidence</source>
         <translation>Ponderación de las pruebas</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1710"/>
+        <location filename="../moluscedialog.py" line="1905"/>
         <source>Multi Criteria Evaluation</source>
         <translation>Evaluación multicriterio</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1695"/>
+        <location filename="../moluscedialog.py" line="1890"/>
         <source>Logistic Regression</source>
         <translation>Regresión logística</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1298"/>
+        <location filename="../moluscedialog.py" line="1493"/>
         <source>All</source>
         <translation>Completa</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1299"/>
+        <location filename="../moluscedialog.py" line="1494"/>
         <source>Random</source>
         <translation>Aleatorio</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1300"/>
+        <location filename="../moluscedialog.py" line="1495"/>
         <source>Stratified</source>
         <translation>Estratificado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1308"/>
+        <location filename="../moluscedialog.py" line="1503"/>
         <source>Multiple-resolution budget</source>
         <translation>Magnitudes de error a diferentes escalas espaciales</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1406"/>
+        <location filename="../moluscedialog.py" line="1601"/>
         <source>Correlation checking</source>
         <translation>Cálculo de la correlación</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1521"/>
+        <location filename="../moluscedialog.py" line="1716"/>
         <source>Not applicable</source>
         <translation>No aplicable</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1553"/>
+        <location filename="../moluscedialog.py" line="1748"/>
         <source>sq. </source>
         <translation>cuadrados </translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1597"/>
+        <location filename="../moluscedialog.py" line="1792"/>
         <source>Class color</source>
         <translation>Color de la clase</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Nothing to save, samples were not yet generated as the model was not trained. Train the model first.</source>
         <translation>No se puede guardar, aún no se han generado ejemplos porque no se ha entrenado el modelo. Entrene primero el modelo.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Missed samples</source>
         <translation>No se ponen muestras</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1819"/>
+        <location filename="../moluscedialog.py" line="2014"/>
         <source>Save file</source>
         <translation>Guardar fichero</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1758"/>
+        <location filename="../moluscedialog.py" line="1953"/>
         <source>Shape files (*.shp *.SHP *.Shp)</source>
         <translation>Shape files (*.shp *.SHP *.Shp)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file</source>
         <translation>No se puede guardar el fichero</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Can&apos;t open file</source>
         <translation>No se puede abrir el fichero</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1813"/>
+        <location filename="../moluscedialog.py" line="2008"/>
         <source>Select Directory name</source>
         <translation>Seleccione el nombre del directorio</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>Open file</source>
         <translation>Abrir fichero</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1871"/>
+        <location filename="../moluscedialog.py" line="2066"/>
         <source>An unknown error occurs during validation procedure</source>
         <translation>Se ha producido un error desconocido durante el procedimiento de validación</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1898"/>
+        <location filename="../moluscedialog.py" line="2093"/>
         <source>Can&apos;t load raster %s</source>
         <translation>No se puede cargar el raster %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2066"/>
+        <location filename="../moluscedialog.py" line="2261"/>
         <source>Persistent</source>
         <translation>Persistente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>Raster must store codes of a nominal variable</source>
         <translation>La raster debe almacenar los códigos nominales de las variables</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>The raster has a lot of different values. Does the raster store a nominal variable?</source>
         <translation>El raster tiene muchos valores diferentes. ¿El raster almacena una variable nominal?</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="452"/>
+        <location filename="../moluscedialog.py" line="618"/>
         <source>Geometries of the initial raster and raster &apos;{}&apos; are different!</source>
         <translation>Las características espaciales de los rásters de estado inicial y final '{}' no coinciden!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file: &apos;{}&apos;</source>
         <translation>No se puede leer el fichero: '{}'</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file: &apos;{}&apos;</source>
         <translation>No se puede guardar el fichero: '{}'</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Error loading output shapefile:
 {}</source>
         <translation>Error al cargar el fichero de salida:
 {}</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Factor raster is not selected. Please specify it and try again</source>
         <translation>El mapa de influencia de factores no está seleccionado. Por favor, especifique un mapa de influencia de factores e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="782"/>
+        <location filename="../moluscedialog.py" line="976"/>
         <source>Model not selected. Please select and train model.</source>
         <translation>No se ha seleccionado ningún modelo. Por favor, seleccione y entrene un modelo.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable to the file: &apos;{}&apos; because it contains continuous value</source>
         <translation>Kappa no es aplicable al fichero: '{}' porque contiene valor continuo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Selected model doesn&apos;t use samples</source>
         <translation>El modelo seleccionado no utiliza muestras</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1864"/>
+        <location filename="../moluscedialog.py" line="2059"/>
         <source>The system is out of memory during validation procedure</source>
         <translation>Se ha producido un desbordamiento de la memoria asignada durante el procedimiento de validación</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1539"/>
+        <location filename="../moluscedialog.py" line="1734"/>
         <source>metre</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1540"/>
+        <location filename="../moluscedialog.py" line="1735"/>
         <source>meter</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1541"/>
+        <location filename="../moluscedialog.py" line="1736"/>
         <source>meters</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1542"/>
+        <location filename="../moluscedialog.py" line="1737"/>
         <source>metres</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1543"/>
+        <location filename="../moluscedialog.py" line="1738"/>
         <source>unknown</source>
         <translation>desconocido</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 perfect quantity inform.</source>
         <translation>Nivel ideal de información sobre la posición,
 nivel ideal de información sobre la cantidad.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 no quantity inform.</source>
         <translation>No hay información sobre la posición,
 no hay información sobre la cantidad.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 medium quantity inform.</source>
         <translation>No hay información sobre la posición,
 nivel medio de información sobre la cantidad.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Medium location,
 medium quantity inform.</source>
         <translation>Nivel medio de información sobre la posición,
 nivel medio de información sobre la cantidad.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 medium quantity inform.</source>
         <translation>Nivel ideal de información sobre la posición,
 nivel medio de información sobre la cantidad.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="243"/>
+        <location filename="../moluscedialog.py" line="251"/>
         <source>Set initial layer to %s</source>
         <translation>Establecer raster de estados iniciales a %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1230"/>
+        <location filename="../moluscedialog.py" line="1424"/>
         <source>Process of Validation Map creating is finished</source>
         <translation>El proceso de creación del mapa de validación ha finalizado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>File &apos;{}&apos; is used in the QGIS project. It is not possible to overwrite the file, specify a different file name and try again</source>
         <translation>El fichero '{}' se utiliza en el proyecto QGIS. No es posible sobrescribir el fichero, especifique un nombre de fichero diferente e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="642"/>
+        <location filename="../moluscedialog.py" line="810"/>
         <source>Directory of transition potential maps is not set. Please specify it and try again</source>
         <translation>El directorio de mapas de potencial de transición no está especificado. Por favor, especifíquelo e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Overwrite file</source>
         <translation>Sobrescribir fichero</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Files with the specified prefix already exist in this directory. This may cause the files to be overwritten. Are you sure you want to continue?</source>
         <translation>Los ficheros con el prefijo especificado ya existen en este directorio. Esto puede provocar que los ficheros se sobrescriban. ¿Está seguro de que desea continuar?</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="742"/>
+        <location filename="../moluscedialog.py" line="910"/>
         <source>Can&apos;t save file in the specified path &apos;{}&apos;. Please specify output path correctly and try again</source>
         <translation>No se puede guardar el fichero en la ruta especificada '{}'. Por favor, especifique correctamente la ruta de salida e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Different characteristics of rasters</source>
         <translation>Diferentes características de los rásters</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Characteristics of the reference and simulated rasters are different!</source>
         <translation>Las características de los rásteres de referencia y simulados son diferentes!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Geometries of the reference and simulated rasters are different!</source>
         <translation>Las geometrías de los rásteres de referencia y simulados son diferentes!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2018"/>
+        <location filename="../moluscedialog.py" line="2213"/>
         <source>Init raster should be in PseudoColor or Paletted mode. Style not applied.</source>
         <translation>La raster inicial debe estar en modo PseudoColor o Paleta. Estilo no aplicado.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>Can&apos;t rewrite file</source>
         <translation>No se puede reescribir el fichero</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="761"/>
+        <location filename="../moluscedialog.py" line="929"/>
         <source>Can&apos;t save files with the same output path &apos;{}&apos;. Please specify different output paths and try again</source>
         <translation>No se pueden guardar ficheros con la misma ruta de salida '{}'. Por favor, especifique diferentes rutas de salida e inténtelo de nuevo</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="429"/>
+        <source>Added factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="513"/>
+        <source>Removed factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="539"/>
+        <source>Factors list (sim) cleared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Different number of variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Model is trained using {} variables, and simulation was set up with {} variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Different number of bands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Training variable {} and simulation variable {} have different number of bands, {} and {} respectively</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Consistancy is checked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Training variables and Simulation variables are matched!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="941"/>
+        <source>Factors rasters for simulation are not set. Please specify them and try again, or disable their usage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="951"/>
+        <source>Separate variables version consistency is not checked</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -974,17 +1029,17 @@ nivel medio de información sobre la cantidad.</translation>
         <translation>Final &gt;&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="105"/>
+        <location filename="../ui/moluscedialogbase.ui" line="638"/>
         <source>&lt;&lt; Remove all</source>
         <translation>&lt;&lt; Eliminar todo</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="112"/>
+        <location filename="../ui/moluscedialogbase.ui" line="631"/>
         <source>&lt;&lt; Remove</source>
         <translation>&lt;&lt; Eliminar</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="119"/>
+        <location filename="../ui/moluscedialogbase.ui" line="611"/>
         <source>Add &gt;&gt;</source>
         <translation>Añadir &gt;&gt;</translation>
     </message>
@@ -1094,22 +1149,22 @@ nivel medio de información sobre la cantidad.</translation>
         <translation>Simulación de Autómatas Celulares</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="725"/>
+        <location filename="../ui/moluscedialogbase.ui" line="797"/>
         <source>Browse...</source>
         <translation>Selección de ficheros...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="574"/>
+        <location filename="../ui/moluscedialogbase.ui" line="540"/>
         <source>Certainty function</source>
         <translation>Un mapa de confianza en la previsión</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="554"/>
+        <location filename="../ui/moluscedialogbase.ui" line="564"/>
         <source>Simulation result</source>
         <translation>Resultado de la simulación</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="540"/>
+        <location filename="../ui/moluscedialogbase.ui" line="550"/>
         <source>Number of simulation iterations</source>
         <translation>Número de iteraciones de simulación</translation>
     </message>
@@ -1119,77 +1174,77 @@ nivel medio de información sobre la cantidad.</translation>
         <translation>potential_</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="620"/>
+        <location filename="../ui/moluscedialogbase.ui" line="692"/>
         <source>Start</source>
         <translation>Inicio</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="643"/>
+        <location filename="../ui/moluscedialogbase.ui" line="715"/>
         <source>Validation</source>
         <translation>Validación</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="683"/>
+        <location filename="../ui/moluscedialogbase.ui" line="755"/>
         <source>Create...</source>
         <translation>Crear...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="690"/>
+        <location filename="../ui/moluscedialogbase.ui" line="762"/>
         <source>Validation Map</source>
         <translation>Mapa de errores</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="697"/>
+        <location filename="../ui/moluscedialogbase.ui" line="769"/>
         <source>Simulated Map</source>
         <translation>Mapa de resultados de la simulación</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="711"/>
+        <location filename="../ui/moluscedialogbase.ui" line="783"/>
         <source>Reference Map</source>
         <translation>Mapa de valores verdaderos</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="752"/>
+        <location filename="../ui/moluscedialogbase.ui" line="824"/>
         <source>Number of validation iterations</source>
         <translation>Número de iteraciones de validación</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="759"/>
+        <location filename="../ui/moluscedialogbase.ui" line="831"/>
         <source>Check persistent classes</source>
         <translation>Calcular las clases persistentes</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="785"/>
+        <location filename="../ui/moluscedialogbase.ui" line="857"/>
         <source>% of Correctness</source>
         <translation>% de corrección</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="857"/>
+        <location filename="../ui/moluscedialogbase.ui" line="929"/>
         <source>Calculate kappa</source>
         <translation>Calcular las estadísticas kappa</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="864"/>
+        <location filename="../ui/moluscedialogbase.ui" line="936"/>
         <source>Start validation</source>
         <translation>Iniciar validación</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="874"/>
+        <location filename="../ui/moluscedialogbase.ui" line="946"/>
         <source>Messages</source>
         <translation>Mensajes</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="811"/>
+        <location filename="../ui/moluscedialogbase.ui" line="883"/>
         <source>Kappa (overall)</source>
         <translation>Kappa (en general)</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="837"/>
+        <location filename="../ui/moluscedialogbase.ui" line="909"/>
         <source>Kappa (histogram)</source>
         <translation>Kappa (histograma)</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="850"/>
+        <location filename="../ui/moluscedialogbase.ui" line="922"/>
         <source>Kappa (location)</source>
         <translation>Kappa (posición)</translation>
     </message>
@@ -1212,6 +1267,16 @@ nivel medio de información sobre la cantidad.</translation>
         <location filename="../ui/moluscedialogbase.ui" line="484"/>
         <source>Select Directory...</source>
         <translation>Seleccionar directorio...</translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="596"/>
+        <source>Set separate spatial variables version for simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="645"/>
+        <source>Check consistency</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/molusce/i18n/molusce_fr.ts
+++ b/src/molusce/i18n/molusce_fr.ts
@@ -404,551 +404,606 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MolusceDialog</name>
     <message>
-        <location filename="../moluscedialog.py" line="176"/>
+        <location filename="../moluscedialog.py" line="184"/>
         <source>Start logging</source>
         <translation>Démarrer l'enregistrement</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Missed selected row</source>
         <translation>Ligne sélectionnée manquante</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="224"/>
+        <location filename="../moluscedialog.py" line="232"/>
         <source>Initial raster is not selected. Please specify input data and try again</source>
         <translation>Raster initiale n'est pas sélectionné. S'il vous plaît précisez les données d'entrée et réessayez</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="363"/>
+        <location filename="../moluscedialog.py" line="431"/>
         <source>Memory Error occurred (loading raster %s). Perhaps the system is low on memory.</source>
         <translation>Une erreur de mémoire s'est produite (chargement raster %s). Peut-être que le système manque de mémoire.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="278"/>
+        <location filename="../moluscedialog.py" line="286"/>
         <source>Final raster is not selected. Please specify input data and try again</source>
         <translation>Raster final n'est pas sélectionné. S'il vous plaît précisez les données d'entrée et réessayez</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="296"/>
+        <location filename="../moluscedialog.py" line="304"/>
         <source>Set final layer to %s</source>
         <translation>Définir la couche finale à %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="326"/>
+        <location filename="../moluscedialog.py" line="394"/>
         <source>Factor raster is not selected. Please specify input data and try again</source>
         <translation>Raster facteur n'est pas sélectionné. S'il vous plaît précisez les données d'entrée et réessayez</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="361"/>
+        <location filename="../moluscedialog.py" line="369"/>
         <source>Added factor layer %s</source>
         <translation>Couche facteur ajouté %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error</source>
         <translation>Erreur de memoire</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error occurred. Perhaps the system is low on memory.</source>
         <translation>Une erreur de mémoire s'est produite. Peut-être que le système manque de mémoire.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="413"/>
+        <location filename="../moluscedialog.py" line="480"/>
         <source>Removed factor layer %s</source>
         <translation>Couche facteur supprimé %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="427"/>
+        <location filename="../moluscedialog.py" line="527"/>
         <source>Factors list cleared</source>
         <translation>Liste des facteurs dégagé</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Missed input data</source>
         <translation>Données d'entrée manquantes</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="772"/>
+        <location filename="../moluscedialog.py" line="964"/>
         <source>Factors rasters is not set. Please specify them and try again</source>
         <translation>Facteurs rasters ne sont pas définis. S'il vous plaît indiquez-les et essayez à nouveau</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="548"/>
+        <location filename="../moluscedialog.py" line="716"/>
         <source>Initial or final raster is not set. Please specify input data and try again</source>
         <translation>Raster initial ou final n'est pas défini. S'il vous plaît précisez les données d'entrée et réessayez</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Different geometry</source>
         <translation>Géométrie différente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="461"/>
+        <location filename="../moluscedialog.py" line="573"/>
         <source>Geometries of the initial raster and final raster are different!</source>
         <translation>Géométrie du raster initial et final sont différents!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometry is matched</source>
         <translation>La géométrie correspond</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometries of the rasters are matched!</source>
         <translation>La géométrie des rasters correspond!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="493"/>
+        <location filename="../moluscedialog.py" line="661"/>
         <source>Memory Error occurred (correlation checking). Perhaps the system is low on memory.</source>
         <translation>Une erreur de mémoire s'est produite (contrôle de la corrélation). Peut-être que le système manque de mémoire.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="542"/>
+        <location filename="../moluscedialog.py" line="710"/>
         <source>Class statistics and transition matrix are updated</source>
         <translation>Les statistiques de classe et de la matrice de transition sont mises à jour</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="557"/>
+        <location filename="../moluscedialog.py" line="725"/>
         <source>Save change map</source>
         <translation>Enregistrer la carte des changements</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</source>
         <translation>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1152"/>
+        <location filename="../moluscedialog.py" line="1346"/>
         <source>No file selected</source>
         <translation>Aucun fichier sélectionné</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="615"/>
+        <location filename="../moluscedialog.py" line="783"/>
         <source>Change Map is created</source>
         <translation>Carte des changements créée</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Initial raster is not set. Please specify it and try again</source>
         <translation>Raster initial n'est pas définis. S'il vous plaît indiquez-le et essayez à nouveau</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="632"/>
+        <location filename="../moluscedialog.py" line="800"/>
         <source>Prefix of transition potential maps is not set. Please specify it and try again</source>
         <translation>Préfixe des cartes de transition potentiels n'est pas définie. S'il vous plaît précisez les données d'entrée et réessayez</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Missed model</source>
         <translation>Modèle raté</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Missed transition matrix</source>
         <translation>Matrice de transition raté</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Please calculate transition matrix and try again</source>
         <translation>Vous êtes priés de calculer la matrice de transition et d'essayer à nouveau</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="816"/>
+        <location filename="../moluscedialog.py" line="1010"/>
         <source>Simulation process is started</source>
         <translation>Le processus de simulation est lancée</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="852"/>
+        <location filename="../moluscedialog.py" line="1046"/>
         <source>Output path for risk function map is not set. Skipping this step</source>
         <translation>Chemin de sortie pour la carte de la fonction risque n'a pas été défini. Cette étape a été sautée</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="902"/>
+        <location filename="../moluscedialog.py" line="1096"/>
         <source>Output path for simulated risk map is not set. Skipping this step</source>
         <translation>Chemin de sortie pour la carte des risques simulés n'a pas été réglé. Cette étape a été sautée</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Not implemented yet</source>
         <translation>Pas encore implémenté</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Transition potentials not implemented yet for the model.</source>
         <translation>Potentiels de transition ne sont pas encore mises en œuvre pour le modèle.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="943"/>
+        <location filename="../moluscedialog.py" line="1137"/>
         <source>Simulation process is finished</source>
         <translation>Processus de simulation est terminée</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file</source>
         <translation>Impossible de lire le fichier</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="988"/>
+        <location filename="../moluscedialog.py" line="1182"/>
         <source>Validation process is started</source>
         <translation>Le processus de validation est démarré</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1030"/>
+        <location filename="../moluscedialog.py" line="1224"/>
         <source>Validation process is finished</source>
         <translation>Le processus de validation est terminé</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable</source>
         <translation>Kappa n'est pas applicable</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1092"/>
+        <location filename="../moluscedialog.py" line="1286"/>
         <source>Kappa validation process is started</source>
         <translation>Processus de validation Kappa est démarré</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1111"/>
+        <location filename="../moluscedialog.py" line="1305"/>
         <source>Kappa validation process is finished</source>
         <translation>Processus de validation Kappa est terminé</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1144"/>
+        <location filename="../moluscedialog.py" line="1338"/>
         <source>Save validation map</source>
         <translation>Enregistration de la carte de validation</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1202"/>
+        <location filename="../moluscedialog.py" line="1396"/>
         <source>Process of Validation Map creating is started</source>
         <translation>Processus de validation de la carte est démarré</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1486"/>
+        <location filename="../moluscedialog.py" line="1681"/>
         <source>Pearson&apos;s Correlation</source>
         <translation>Corrélation de Pearson</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1496"/>
+        <location filename="../moluscedialog.py" line="1691"/>
         <source>Cramer&apos;s Coefficient</source>
         <translation>Coefficient de Cramer</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1511"/>
+        <location filename="../moluscedialog.py" line="1706"/>
         <source>Joint Information Uncertainty</source>
         <translation>Incertitude d'Information Conjoint</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1282"/>
+        <location filename="../moluscedialog.py" line="1477"/>
         <source>raster units</source>
         <translation>Unités raster</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1547"/>
+        <location filename="../moluscedialog.py" line="1742"/>
         <source>sq. km.</source>
         <translation>km²</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1549"/>
+        <location filename="../moluscedialog.py" line="1744"/>
         <source>ha</source>
         <translation>ha</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1700"/>
+        <location filename="../moluscedialog.py" line="1895"/>
         <source>Artificial Neural Network (Multi-layer Perceptron)</source>
         <translation>Réseaux neuronaux (perceptron multicouche)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1705"/>
+        <location filename="../moluscedialog.py" line="1900"/>
         <source>Weights of Evidence</source>
         <translation>Signification du trait</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1710"/>
+        <location filename="../moluscedialog.py" line="1905"/>
         <source>Multi Criteria Evaluation</source>
         <translation>Évaluation multicritères</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1695"/>
+        <location filename="../moluscedialog.py" line="1890"/>
         <source>Logistic Regression</source>
         <translation>Régression logistique</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1298"/>
+        <location filename="../moluscedialog.py" line="1493"/>
         <source>All</source>
         <translation>Tout</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1299"/>
+        <location filename="../moluscedialog.py" line="1494"/>
         <source>Random</source>
         <translation>Random</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1300"/>
+        <location filename="../moluscedialog.py" line="1495"/>
         <source>Stratified</source>
         <translation>Stratifié</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1308"/>
+        <location filename="../moluscedialog.py" line="1503"/>
         <source>Multiple-resolution budget</source>
         <translation>Multi-résolution budgétaire</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1406"/>
+        <location filename="../moluscedialog.py" line="1601"/>
         <source>Correlation checking</source>
         <translation>Contrôle de la corrélation</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1521"/>
+        <location filename="../moluscedialog.py" line="1716"/>
         <source>Not applicable</source>
         <translation>Non applicable</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1553"/>
+        <location filename="../moluscedialog.py" line="1748"/>
         <source>sq. </source>
         <translation>carré</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1597"/>
+        <location filename="../moluscedialog.py" line="1792"/>
         <source>Class color</source>
         <translation>Classe de couleur</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Nothing to save, samples were not yet generated as the model was not trained. Train the model first.</source>
         <translation>Rien à sauver, les échantillons n'ont pas encore été générés vu que le modèle n'a pas été formé. Vous devez d'abord entraîner le modèle.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Missed samples</source>
         <translation>Échantillons manquants</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1819"/>
+        <location filename="../moluscedialog.py" line="2014"/>
         <source>Save file</source>
         <translation>Enregistrer le fichier</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1758"/>
+        <location filename="../moluscedialog.py" line="1953"/>
         <source>Shape files (*.shp *.SHP *.Shp)</source>
         <translation>Shape files (*.shp *.SHP *.Shp)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file</source>
         <translation>Impossible d'enregistrer le fichier</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Can&apos;t open file</source>
         <translation>Impossible d'ouvrir le fichier</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1813"/>
+        <location filename="../moluscedialog.py" line="2008"/>
         <source>Select Directory name</source>
         <translation>Sélectionnez le nom du répertoire</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>Open file</source>
         <translation>Ouvrir le fichier</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1871"/>
+        <location filename="../moluscedialog.py" line="2066"/>
         <source>An unknown error occurs during validation procedure</source>
         <translation>Une erreur inconnue se produit pendant la procédure de validation</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1898"/>
+        <location filename="../moluscedialog.py" line="2093"/>
         <source>Can&apos;t load raster %s</source>
         <translation>Impossible de charger le raster %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2066"/>
+        <location filename="../moluscedialog.py" line="2261"/>
         <source>Persistent</source>
         <translation>Persistent</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>Raster must store codes of a nominal variable</source>
         <translation>La raster doit stocker les codes des variables nominales</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>The raster has a lot of different values. Does the raster store a nominal variable?</source>
         <translation>Le raster a beaucoup de valeurs différentes. Le raster stocke-t-il une variable nominale?</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="452"/>
+        <location filename="../moluscedialog.py" line="618"/>
         <source>Geometries of the initial raster and raster &apos;{}&apos; are different!</source>
         <translation>Les caractéristiques spatiales des rasters d'état de début et de fin '{} ' ne correspondent pas!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file: &apos;{}&apos;</source>
         <translation>Impossible de lire le fichier : '{}'</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file: &apos;{}&apos;</source>
         <translation>Impossible d'enregistrer le fichier : '{}'</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Error loading output shapefile:
 {}</source>
         <translation>Erreur lors du chargement du fichier de sortie:
 {}</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Factor raster is not selected. Please specify it and try again</source>
         <translation>La carte d'influence des facteurs n'est pas sélectionnée. Veuillez spécifier une carte d'influence des facteurs et réessayer</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="782"/>
+        <location filename="../moluscedialog.py" line="976"/>
         <source>Model not selected. Please select and train model.</source>
         <translation>Aucun modèle n'a été sélectionné. Veuillez sélectionner et former un modèle.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable to the file: &apos;{}&apos; because it contains continuous value</source>
         <translation>Le kappa n'est pas applicable au fichier: '{}' car il contient une valeur continue</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Selected model doesn&apos;t use samples</source>
         <translation>Le modèle sélectionné n'utilise pas d'échantillons</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1864"/>
+        <location filename="../moluscedialog.py" line="2059"/>
         <source>The system is out of memory during validation procedure</source>
         <translation>Un débordement de la mémoire allouée s'est produit pendant la procédure de validation</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1539"/>
+        <location filename="../moluscedialog.py" line="1734"/>
         <source>metre</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1540"/>
+        <location filename="../moluscedialog.py" line="1735"/>
         <source>meter</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1541"/>
+        <location filename="../moluscedialog.py" line="1736"/>
         <source>meters</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1542"/>
+        <location filename="../moluscedialog.py" line="1737"/>
         <source>metres</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1543"/>
+        <location filename="../moluscedialog.py" line="1738"/>
         <source>unknown</source>
         <translation>inconnue</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 perfect quantity inform.</source>
         <translation>Niveau idéal d'information sur le poste,
 niveau idéal d'information sur la quantité.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 no quantity inform.</source>
         <translation>Aucune information sur le poste,
 aucune information sur la quantité.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 medium quantity inform.</source>
         <translation>Aucune information sur le poste,
 niveau moyen d'information sur la quantité.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Medium location,
 medium quantity inform.</source>
         <translation>Niveau moyen d'information sur le poste,
 niveau moyen d'information sur la quantité.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 medium quantity inform.</source>
         <translation>Niveau idéal d'information sur le poste,
 niveau moyen d'information sur la quantité.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="243"/>
+        <location filename="../moluscedialog.py" line="251"/>
         <source>Set initial layer to %s</source>
         <translation>Définir la couche initiale à %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1230"/>
+        <location filename="../moluscedialog.py" line="1424"/>
         <source>Process of Validation Map creating is finished</source>
         <translation>Le processus de création de la carte de validation est terminé</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>File &apos;{}&apos; is used in the QGIS project. It is not possible to overwrite the file, specify a different file name and try again</source>
         <translation>Le fichier '{}' est utilisé dans le projet QGIS. Il n'est pas possible d'écraser le fichier, indiquez un nom de fichier différent et réessayez</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="642"/>
+        <location filename="../moluscedialog.py" line="810"/>
         <source>Directory of transition potential maps is not set. Please specify it and try again</source>
         <translation>Le répertoire des cartes de potentiel de transition n'est pas défini. Veuillez le spécifier et réessayer</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Overwrite file</source>
         <translation>Ecraser le fichier</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Files with the specified prefix already exist in this directory. This may cause the files to be overwritten. Are you sure you want to continue?</source>
         <translation>Les fichiers portant le préfixe spécifié existent déjà dans ce répertoire. Cela peut entraîner l'écrasement des fichiers. Êtes-vous sûr de vouloir continuer?</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="742"/>
+        <location filename="../moluscedialog.py" line="910"/>
         <source>Can&apos;t save file in the specified path &apos;{}&apos;. Please specify output path correctly and try again</source>
         <translation>Impossible d'enregistrer le fichier dans le chemin spécifié '{}'. Veuillez spécifier correctement le chemin de sortie et réessayer</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Different characteristics of rasters</source>
         <translation>Différentes caractéristiques des rasters</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Characteristics of the reference and simulated rasters are different!</source>
         <translation>Les caractéristiques des rasters de référence et simulés sont différentes!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Geometries of the reference and simulated rasters are different!</source>
         <translation>Les géométries des rasters de référence et simulés sont différentes!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2018"/>
+        <location filename="../moluscedialog.py" line="2213"/>
         <source>Init raster should be in PseudoColor or Paletted mode. Style not applied.</source>
         <translation>Le raster d'initialisation doit être en mode pseudo-couleur ou en mode palette. Style non appliqué.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>Can&apos;t rewrite file</source>
         <translation>Impossible de réécrire le fichier</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="761"/>
+        <location filename="../moluscedialog.py" line="929"/>
         <source>Can&apos;t save files with the same output path &apos;{}&apos;. Please specify different output paths and try again</source>
         <translation>Impossible d'enregistrer des fichiers avec le même chemin de sortie '{}'. Veuillez spécifier des chemins de sortie différents et réessayer</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="429"/>
+        <source>Added factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="513"/>
+        <source>Removed factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="539"/>
+        <source>Factors list (sim) cleared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Different number of variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Model is trained using {} variables, and simulation was set up with {} variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Different number of bands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Training variable {} and simulation variable {} have different number of bands, {} and {} respectively</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Consistancy is checked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Training variables and Simulation variables are matched!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="941"/>
+        <source>Factors rasters for simulation are not set. Please specify them and try again, or disable their usage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="951"/>
+        <source>Separate variables version consistency is not checked</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -974,17 +1029,17 @@ niveau moyen d'information sur la quantité.</translation>
         <translation>Final &gt;&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="105"/>
+        <location filename="../ui/moluscedialogbase.ui" line="638"/>
         <source>&lt;&lt; Remove all</source>
         <translation>&lt;&lt; Tout supprimer</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="112"/>
+        <location filename="../ui/moluscedialogbase.ui" line="631"/>
         <source>&lt;&lt; Remove</source>
         <translation>&lt;&lt; Supprimer</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="119"/>
+        <location filename="../ui/moluscedialogbase.ui" line="611"/>
         <source>Add &gt;&gt;</source>
         <translation>Ajouter &gt;&gt;</translation>
     </message>
@@ -1094,22 +1149,22 @@ niveau moyen d'information sur la quantité.</translation>
         <translation>Simulation d'Automates Cellulaires</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="725"/>
+        <location filename="../ui/moluscedialogbase.ui" line="797"/>
         <source>Browse...</source>
         <translation>Parcourir...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="574"/>
+        <location filename="../ui/moluscedialogbase.ui" line="540"/>
         <source>Certainty function</source>
         <translation>Carte de la confiance dans les prévisions</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="554"/>
+        <location filename="../ui/moluscedialogbase.ui" line="564"/>
         <source>Simulation result</source>
         <translation>Résultat de la simulation</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="540"/>
+        <location filename="../ui/moluscedialogbase.ui" line="550"/>
         <source>Number of simulation iterations</source>
         <translation>Nombre d'itérations de simulation</translation>
     </message>
@@ -1119,77 +1174,77 @@ niveau moyen d'information sur la quantité.</translation>
         <translation>potential_</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="620"/>
+        <location filename="../ui/moluscedialogbase.ui" line="692"/>
         <source>Start</source>
         <translation>Démarrer</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="643"/>
+        <location filename="../ui/moluscedialogbase.ui" line="715"/>
         <source>Validation</source>
         <translation>Validation</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="683"/>
+        <location filename="../ui/moluscedialogbase.ui" line="755"/>
         <source>Create...</source>
         <translation>Créer...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="690"/>
+        <location filename="../ui/moluscedialogbase.ui" line="762"/>
         <source>Validation Map</source>
         <translation>Carte de Validation</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="697"/>
+        <location filename="../ui/moluscedialogbase.ui" line="769"/>
         <source>Simulated Map</source>
         <translation>Carte Simulée</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="711"/>
+        <location filename="../ui/moluscedialogbase.ui" line="783"/>
         <source>Reference Map</source>
         <translation>Carte de Référence</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="752"/>
+        <location filename="../ui/moluscedialogbase.ui" line="824"/>
         <source>Number of validation iterations</source>
         <translation>Nombre d'itérations de validation</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="759"/>
+        <location filename="../ui/moluscedialogbase.ui" line="831"/>
         <source>Check persistent classes</source>
         <translation>Vérifier les classes persistantes</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="785"/>
+        <location filename="../ui/moluscedialogbase.ui" line="857"/>
         <source>% of Correctness</source>
         <translation>% de certitude</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="857"/>
+        <location filename="../ui/moluscedialogbase.ui" line="929"/>
         <source>Calculate kappa</source>
         <translation>Calculer kappa</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="864"/>
+        <location filename="../ui/moluscedialogbase.ui" line="936"/>
         <source>Start validation</source>
         <translation>Démarrer la validation</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="874"/>
+        <location filename="../ui/moluscedialogbase.ui" line="946"/>
         <source>Messages</source>
         <translation>Messages</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="811"/>
+        <location filename="../ui/moluscedialogbase.ui" line="883"/>
         <source>Kappa (overall)</source>
         <translation>Kappa (général)</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="837"/>
+        <location filename="../ui/moluscedialogbase.ui" line="909"/>
         <source>Kappa (histogram)</source>
         <translation>Kappa (histogramme)</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="850"/>
+        <location filename="../ui/moluscedialogbase.ui" line="922"/>
         <source>Kappa (location)</source>
         <translation>Kappa (lieu)</translation>
     </message>
@@ -1212,6 +1267,16 @@ niveau moyen d'information sur la quantité.</translation>
         <location filename="../ui/moluscedialogbase.ui" line="484"/>
         <source>Select Directory...</source>
         <translation>Sélectionner le répertoire...</translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="596"/>
+        <source>Set separate spatial variables version for simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="645"/>
+        <source>Check consistency</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/molusce/i18n/molusce_it.ts
+++ b/src/molusce/i18n/molusce_it.ts
@@ -404,551 +404,606 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MolusceDialog</name>
     <message>
-        <location filename="../moluscedialog.py" line="176"/>
+        <location filename="../moluscedialog.py" line="184"/>
         <source>Start logging</source>
         <translation>Logging iniziato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Missed selected row</source>
         <translation>Riga selezionata mancante</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="224"/>
+        <location filename="../moluscedialog.py" line="232"/>
         <source>Initial raster is not selected. Please specify input data and try again</source>
         <translation>Il raster iniziale non è stato selezionato. Si prega di specificarlo e riprovare</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="278"/>
+        <location filename="../moluscedialog.py" line="286"/>
         <source>Final raster is not selected. Please specify input data and try again</source>
         <translation>Il raster finale non è stato selezionato. Si prega di specificarlo e riprovare</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="326"/>
+        <location filename="../moluscedialog.py" line="394"/>
         <source>Factor raster is not selected. Please specify input data and try again</source>
         <translation>I fattori raster non sono stati selezionati. Si prega di specificarli e riprovare</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="427"/>
+        <location filename="../moluscedialog.py" line="527"/>
         <source>Factors list cleared</source>
         <translation>Lista dei fattori eliminata</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Missed input data</source>
         <translation>Input data mancanti</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="548"/>
+        <location filename="../moluscedialog.py" line="716"/>
         <source>Initial or final raster is not set. Please specify input data and try again</source>
         <translation>Il raster iniziale o finale non è stato impostato correttamente. Si prega di specificare i dati di input e riprovare</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1597"/>
+        <location filename="../moluscedialog.py" line="1792"/>
         <source>Class color</source>
         <translation>Classe colore</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="542"/>
+        <location filename="../moluscedialog.py" line="710"/>
         <source>Class statistics and transition matrix are updated</source>
         <translation>Statistiche di classe e matrice di transizione sono stati aggiornati</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="557"/>
+        <location filename="../moluscedialog.py" line="725"/>
         <source>Save change map</source>
         <translation>Salve la mappa dei cambiamenti</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</source>
         <translation>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1152"/>
+        <location filename="../moluscedialog.py" line="1346"/>
         <source>No file selected</source>
         <translation>Nessun file selezionato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Initial raster is not set. Please specify it and try again</source>
         <translation>Il raster iniziale non è stato impostato correttamente. Si prega di specificarlo e riprovare</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="772"/>
+        <location filename="../moluscedialog.py" line="964"/>
         <source>Factors rasters is not set. Please specify them and try again</source>
         <translation>I fattori raster non sono stati impostati correttamente. Si prega di specificarli e riprovare</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Missed model</source>
         <translation>Modello mancante</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Missed transition matrix</source>
         <translation>Matrice di transizione mancante</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Please calculate transition matrix and try again</source>
         <translation>Si prega di calcolare la matrice di transizione e riprovare</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="852"/>
+        <location filename="../moluscedialog.py" line="1046"/>
         <source>Output path for risk function map is not set. Skipping this step</source>
         <translation>Il percorso di ouput per la funzione di rischio non è stata impostata correttamente. Questo passaggio verrà saltato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="902"/>
+        <location filename="../moluscedialog.py" line="1096"/>
         <source>Output path for simulated risk map is not set. Skipping this step</source>
         <translation>Il percorso di ouput per la simulazione della mappa del rischio non è stata impostata correttamente. Questo passaggio verrà saltato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file</source>
         <translation>Il file non può essere letto</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable</source>
         <translation>Kappa non applicabile</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1496"/>
+        <location filename="../moluscedialog.py" line="1691"/>
         <source>Cramer&apos;s Coefficient</source>
         <translation>Coefficiente Cramer</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1511"/>
+        <location filename="../moluscedialog.py" line="1706"/>
         <source>Joint Information Uncertainty</source>
         <translation>Incertezza dell'Entropia Congiunta</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1705"/>
+        <location filename="../moluscedialog.py" line="1900"/>
         <source>Weights of Evidence</source>
         <translation>Significato del tratto</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1710"/>
+        <location filename="../moluscedialog.py" line="1905"/>
         <source>Multi Criteria Evaluation</source>
         <translation>Valutazione multi-criterio</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1695"/>
+        <location filename="../moluscedialog.py" line="1890"/>
         <source>Logistic Regression</source>
         <translation>Regressione logistica</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1298"/>
+        <location filename="../moluscedialog.py" line="1493"/>
         <source>All</source>
         <translation>Tutto</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1308"/>
+        <location filename="../moluscedialog.py" line="1503"/>
         <source>Multiple-resolution budget</source>
         <translation>Bidget risoluzione multipla</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1521"/>
+        <location filename="../moluscedialog.py" line="1716"/>
         <source>Not applicable</source>
         <translation>Non applicabile</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Nothing to save, samples were not yet generated as the model was not trained. Train the model first.</source>
         <translation>Non c'è nulla da salvare, i campioni non sono ancora stati generati poiché il training del modello non è stato effettuato. Si prega di eseguire il training del modello.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Missed samples</source>
         <translation>Campioni mancanti</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1819"/>
+        <location filename="../moluscedialog.py" line="2014"/>
         <source>Save file</source>
         <translation>Salva il file</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1758"/>
+        <location filename="../moluscedialog.py" line="1953"/>
         <source>Shape files (*.shp *.SHP *.Shp)</source>
         <translation>Shape files (*.shp *.SHP *.Shp)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Can&apos;t open file</source>
         <translation>Il file non può essere aperto</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>Open file</source>
         <translation>Apri il file</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="363"/>
+        <location filename="../moluscedialog.py" line="431"/>
         <source>Memory Error occurred (loading raster %s). Perhaps the system is low on memory.</source>
         <translation>Si è verificato un errore durante il caricamento del raster %s. Forse il sistema ha memoria insufficiente.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="296"/>
+        <location filename="../moluscedialog.py" line="304"/>
         <source>Set final layer to %s</source>
         <translation>%s impostato come layer finale</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="361"/>
+        <location filename="../moluscedialog.py" line="369"/>
         <source>Added factor layer %s</source>
         <translation>%s aggiunti come variabile spaziale</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error</source>
         <translation>Errore di memoria</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error occurred. Perhaps the system is low on memory.</source>
         <translation>Si è verificato un errore. Forse il sistema ha memoria insufficiente.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="413"/>
+        <location filename="../moluscedialog.py" line="480"/>
         <source>Removed factor layer %s</source>
         <translation>%s rimossi dalle variabili spaziali</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Different geometry</source>
         <translation>Geometria diversa</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="461"/>
+        <location filename="../moluscedialog.py" line="573"/>
         <source>Geometries of the initial raster and final raster are different!</source>
         <translation>Le geometrie del raster iniziare e finale sono diverse!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometry is matched</source>
         <translation>La geometria corrisponde correttamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometries of the rasters are matched!</source>
         <translation>Le geometrie dei file raster corrisponde correttamente!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="493"/>
+        <location filename="../moluscedialog.py" line="661"/>
         <source>Memory Error occurred (correlation checking). Perhaps the system is low on memory.</source>
         <translation>Si è verificato un errore (controllo della correlazione). Forse il sistema ha memoria insufficiente.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="615"/>
+        <location filename="../moluscedialog.py" line="783"/>
         <source>Change Map is created</source>
         <translation>La mappa dei cambiamenti è stata creata con successo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="632"/>
+        <location filename="../moluscedialog.py" line="800"/>
         <source>Prefix of transition potential maps is not set. Please specify it and try again</source>
         <translation>Prefisso delle mappe di transizione potenziali non è impostato. Si prega di specificarlo e riprovare nuovamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="816"/>
+        <location filename="../moluscedialog.py" line="1010"/>
         <source>Simulation process is started</source>
         <translation>Processo di simulatione iniziato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Not implemented yet</source>
         <translation>Non ancora implementato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Transition potentials not implemented yet for the model.</source>
         <translation>Le transizioni potenziali non sono state ancora implementate per il modello.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="943"/>
+        <location filename="../moluscedialog.py" line="1137"/>
         <source>Simulation process is finished</source>
         <translation>Processo di simulazione concluso</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="988"/>
+        <location filename="../moluscedialog.py" line="1182"/>
         <source>Validation process is started</source>
         <translation>Processo di convalida iniziato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1030"/>
+        <location filename="../moluscedialog.py" line="1224"/>
         <source>Validation process is finished</source>
         <translation>Processo di convalida concluso</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1092"/>
+        <location filename="../moluscedialog.py" line="1286"/>
         <source>Kappa validation process is started</source>
         <translation>Processo di convalida kappa iniziato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1111"/>
+        <location filename="../moluscedialog.py" line="1305"/>
         <source>Kappa validation process is finished</source>
         <translation>Processo di convalida kappa concluso</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1144"/>
+        <location filename="../moluscedialog.py" line="1338"/>
         <source>Save validation map</source>
         <translation>Salva mappa di convalida</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1202"/>
+        <location filename="../moluscedialog.py" line="1396"/>
         <source>Process of Validation Map creating is started</source>
         <translation>Processo per la creazione della mappa di convalida iniziato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1486"/>
+        <location filename="../moluscedialog.py" line="1681"/>
         <source>Pearson&apos;s Correlation</source>
         <translation>Correlazione di Pearson</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1282"/>
+        <location filename="../moluscedialog.py" line="1477"/>
         <source>raster units</source>
         <translation>Unità raster</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1547"/>
+        <location filename="../moluscedialog.py" line="1742"/>
         <source>sq. km.</source>
         <translation>km²</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1549"/>
+        <location filename="../moluscedialog.py" line="1744"/>
         <source>ha</source>
         <translation>ha</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1700"/>
+        <location filename="../moluscedialog.py" line="1895"/>
         <source>Artificial Neural Network (Multi-layer Perceptron)</source>
         <translation>Reti neurali (percettrone multistrato)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1299"/>
+        <location filename="../moluscedialog.py" line="1494"/>
         <source>Random</source>
         <translation>Random</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1300"/>
+        <location filename="../moluscedialog.py" line="1495"/>
         <source>Stratified</source>
         <translation>Stratificato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1406"/>
+        <location filename="../moluscedialog.py" line="1601"/>
         <source>Correlation checking</source>
         <translation>Controllo Correlazione</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1553"/>
+        <location filename="../moluscedialog.py" line="1748"/>
         <source>sq. </source>
         <translation>quadri </translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file</source>
         <translation>Il file non può essere salvato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1813"/>
+        <location filename="../moluscedialog.py" line="2008"/>
         <source>Select Directory name</source>
         <translation>Selezionare il nome della directory</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1871"/>
+        <location filename="../moluscedialog.py" line="2066"/>
         <source>An unknown error occurs during validation procedure</source>
         <translation>Errore sconosciuto durante la procedura di convalida</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1898"/>
+        <location filename="../moluscedialog.py" line="2093"/>
         <source>Can&apos;t load raster %s</source>
         <translation>Il raster %s non può essere caricato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2066"/>
+        <location filename="../moluscedialog.py" line="2261"/>
         <source>Persistent</source>
         <translation>Persistente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>Raster must store codes of a nominal variable</source>
         <translation>Il raster deve memorizzare i codici di una variabile nominale</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>The raster has a lot of different values. Does the raster store a nominal variable?</source>
         <translation>Il raster ha molti valori diversi. Il raster memorizza una variabile nominale?</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="452"/>
+        <location filename="../moluscedialog.py" line="618"/>
         <source>Geometries of the initial raster and raster &apos;{}&apos; are different!</source>
         <translation>Le caratteristiche spaziali dei raster dello stato iniziale e finale '{}' non coincidono!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file: &apos;{}&apos;</source>
         <translation>Impossibile leggere il file: '{}'</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file: &apos;{}&apos;</source>
         <translation>Impossibile salvare il file: '{}'</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Error loading output shapefile:
 {}</source>
         <translation>Errore durante il caricamento del file di output:
 {}</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Factor raster is not selected. Please specify it and try again</source>
         <translation>Non è selezionata alcuna mappa di influenza fattore. Si prega di indicare la mappa di influenza del fattore e riprovare</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="782"/>
+        <location filename="../moluscedialog.py" line="976"/>
         <source>Model not selected. Please select and train model.</source>
         <translation>Il modello non è selezionato. Si prega di scegliere e addestrare il modello.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable to the file: &apos;{}&apos; because it contains continuous value</source>
         <translation>Kappa non è applicabile al file: '{}' in quanto contiene un valore continuo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Selected model doesn&apos;t use samples</source>
         <translation>Il modello selezionato non utilizza campioni</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1864"/>
+        <location filename="../moluscedialog.py" line="2059"/>
         <source>The system is out of memory during validation procedure</source>
         <translation>Durante la procedura di convalida si è verificato un overflow della memoria allocata</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1539"/>
+        <location filename="../moluscedialog.py" line="1734"/>
         <source>metre</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1540"/>
+        <location filename="../moluscedialog.py" line="1735"/>
         <source>meter</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1541"/>
+        <location filename="../moluscedialog.py" line="1736"/>
         <source>meters</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1542"/>
+        <location filename="../moluscedialog.py" line="1737"/>
         <source>metres</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1543"/>
+        <location filename="../moluscedialog.py" line="1738"/>
         <source>unknown</source>
         <translation>sconosciuto</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 perfect quantity inform.</source>
         <translation>Livello ideale di informazioni sulla posizione,
 livello ideale di informazioni sulla quantità.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 no quantity inform.</source>
         <translation>Nessuna informazione sulla posizione,
 nessuna informazione sulla quantità.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 medium quantity inform.</source>
         <translation>Nessuna informazione sulla posizione,
 livello medio di informazioni sulla quantità.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Medium location,
 medium quantity inform.</source>
         <translation>Livello medio di informazioni sulla posizione,
 livello medio di informazioni sulla quantità.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 medium quantity inform.</source>
         <translation>Livello ideale di informazioni sulla posizione,
 livello medio di informazioni sulla quantità.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="243"/>
+        <location filename="../moluscedialog.py" line="251"/>
         <source>Set initial layer to %s</source>
         <translation>Imposta il livello iniziale a %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1230"/>
+        <location filename="../moluscedialog.py" line="1424"/>
         <source>Process of Validation Map creating is finished</source>
         <translation>Processo di creazione della mappa di convalida è terminato</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>File &apos;{}&apos; is used in the QGIS project. It is not possible to overwrite the file, specify a different file name and try again</source>
         <translation>Il file '{}' è utilizzato nel progetto QGIS. Non è possibile sovrascrivere il file, specificare un nome di file diverso e riprovare</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="642"/>
+        <location filename="../moluscedialog.py" line="810"/>
         <source>Directory of transition potential maps is not set. Please specify it and try again</source>
         <translation>La directory delle mappe del potenziale di transizione non è impostata. Specificarla e riprovare</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Overwrite file</source>
         <translation>Sovrascrivere il file</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Files with the specified prefix already exist in this directory. This may cause the files to be overwritten. Are you sure you want to continue?</source>
         <translation>I file con il prefisso specificato esistono già in questa directory. Questo potrebbe causare la sovrascrittura dei file. Siete sicuri di voler continuare?</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="742"/>
+        <location filename="../moluscedialog.py" line="910"/>
         <source>Can&apos;t save file in the specified path &apos;{}&apos;. Please specify output path correctly and try again</source>
         <translation>Impossibile salvare il file nel percorso specificato '{}'. Specificare correttamente il percorso di output e riprovare</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Different characteristics of rasters</source>
         <translation>Caratteristiche diverse dei raster</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Characteristics of the reference and simulated rasters are different!</source>
         <translation>Le caratteristiche dei raster di riferimento e di quelli simulati sono diverse!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Geometries of the reference and simulated rasters are different!</source>
         <translation>Le geometrie dei raster di riferimento e di quelli simulati sono diverse!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2018"/>
+        <location filename="../moluscedialog.py" line="2213"/>
         <source>Init raster should be in PseudoColor or Paletted mode. Style not applied.</source>
         <translation>Il raster di ingresso deve essere in modalità PseudoColor o Paletted. Lo stile non viene applicato.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>Can&apos;t rewrite file</source>
         <translation>Impossibile riscrivere il file</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="761"/>
+        <location filename="../moluscedialog.py" line="929"/>
         <source>Can&apos;t save files with the same output path &apos;{}&apos;. Please specify different output paths and try again</source>
         <translation>Non è possibile salvare i file con lo stesso percorso di output '{}'. Specificare percorsi di output diversi e riprovare</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="429"/>
+        <source>Added factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="513"/>
+        <source>Removed factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="539"/>
+        <source>Factors list (sim) cleared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Different number of variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Model is trained using {} variables, and simulation was set up with {} variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Different number of bands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Training variable {} and simulation variable {} have different number of bands, {} and {} respectively</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Consistancy is checked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Training variables and Simulation variables are matched!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="941"/>
+        <source>Factors rasters for simulation are not set. Please specify them and try again, or disable their usage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="951"/>
+        <source>Separate variables version consistency is not checked</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -974,17 +1029,17 @@ livello medio di informazioni sulla quantità.</translation>
         <translation>Finale &gt;&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="105"/>
+        <location filename="../ui/moluscedialogbase.ui" line="638"/>
         <source>&lt;&lt; Remove all</source>
         <translation>&lt;&lt; Rimuovi tutto</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="112"/>
+        <location filename="../ui/moluscedialogbase.ui" line="631"/>
         <source>&lt;&lt; Remove</source>
         <translation>&lt;&lt; Rimuovi</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="119"/>
+        <location filename="../ui/moluscedialogbase.ui" line="611"/>
         <source>Add &gt;&gt;</source>
         <translation>Aggiungi &gt;&gt;</translation>
     </message>
@@ -1094,22 +1149,22 @@ livello medio di informazioni sulla quantità.</translation>
         <translation>Simulazione Cellular Automata</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="725"/>
+        <location filename="../ui/moluscedialogbase.ui" line="797"/>
         <source>Browse...</source>
         <translation>Sfoglia...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="574"/>
+        <location filename="../ui/moluscedialogbase.ui" line="540"/>
         <source>Certainty function</source>
         <translation>Mappa della fiducia nelle previsioni</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="554"/>
+        <location filename="../ui/moluscedialogbase.ui" line="564"/>
         <source>Simulation result</source>
         <translation>Risultati della simulazione</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="540"/>
+        <location filename="../ui/moluscedialogbase.ui" line="550"/>
         <source>Number of simulation iterations</source>
         <translation>Numero di iterazioni durtante la simulazione</translation>
     </message>
@@ -1119,77 +1174,77 @@ livello medio di informazioni sulla quantità.</translation>
         <translation>potential_</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="620"/>
+        <location filename="../ui/moluscedialogbase.ui" line="692"/>
         <source>Start</source>
         <translation>Inizia</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="643"/>
+        <location filename="../ui/moluscedialogbase.ui" line="715"/>
         <source>Validation</source>
         <translation>Convalida</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="683"/>
+        <location filename="../ui/moluscedialogbase.ui" line="755"/>
         <source>Create...</source>
         <translation>Crea...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="690"/>
+        <location filename="../ui/moluscedialogbase.ui" line="762"/>
         <source>Validation Map</source>
         <translation>Mappa di convalida</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="697"/>
+        <location filename="../ui/moluscedialogbase.ui" line="769"/>
         <source>Simulated Map</source>
         <translation>Mappa Simulata</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="711"/>
+        <location filename="../ui/moluscedialogbase.ui" line="783"/>
         <source>Reference Map</source>
         <translation>Mappa di Riferimento</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="752"/>
+        <location filename="../ui/moluscedialogbase.ui" line="824"/>
         <source>Number of validation iterations</source>
         <translation>Numero di iterazioni di convalida</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="759"/>
+        <location filename="../ui/moluscedialogbase.ui" line="831"/>
         <source>Check persistent classes</source>
         <translation>Controlla le classi persistenti</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="785"/>
+        <location filename="../ui/moluscedialogbase.ui" line="857"/>
         <source>% of Correctness</source>
         <translation>% di Correttezza</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="857"/>
+        <location filename="../ui/moluscedialogbase.ui" line="929"/>
         <source>Calculate kappa</source>
         <translation>Calcola il kappa</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="864"/>
+        <location filename="../ui/moluscedialogbase.ui" line="936"/>
         <source>Start validation</source>
         <translation>Inizia convalida</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="874"/>
+        <location filename="../ui/moluscedialogbase.ui" line="946"/>
         <source>Messages</source>
         <translation>Messaggi</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="811"/>
+        <location filename="../ui/moluscedialogbase.ui" line="883"/>
         <source>Kappa (overall)</source>
         <translation>Kappa (in generale)</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="837"/>
+        <location filename="../ui/moluscedialogbase.ui" line="909"/>
         <source>Kappa (histogram)</source>
         <translation>Kappa (istogramma)</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="850"/>
+        <location filename="../ui/moluscedialogbase.ui" line="922"/>
         <source>Kappa (location)</source>
         <translation>Kappa (posizione)</translation>
     </message>
@@ -1212,6 +1267,16 @@ livello medio di informazioni sulla quantità.</translation>
         <location filename="../ui/moluscedialogbase.ui" line="484"/>
         <source>Select Directory...</source>
         <translation>Selezionare la directory...</translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="596"/>
+        <source>Set separate spatial variables version for simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="645"/>
+        <source>Check consistency</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/molusce/i18n/molusce_ja.ts
+++ b/src/molusce/i18n/molusce_ja.ts
@@ -404,551 +404,606 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MolusceDialog</name>
     <message>
-        <location filename="../moluscedialog.py" line="1549"/>
+        <location filename="../moluscedialog.py" line="1744"/>
         <source>ha</source>
         <translation>ヘクタール</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1298"/>
+        <location filename="../moluscedialog.py" line="1493"/>
         <source>All</source>
         <translation>全て</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1553"/>
+        <location filename="../moluscedialog.py" line="1748"/>
         <source>sq. </source>
         <translation>平方. </translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="632"/>
+        <location filename="../moluscedialog.py" line="800"/>
         <source>Prefix of transition potential maps is not set. Please specify it and try again</source>
         <translation>遷移ポテンシャル図のプレフィックスが設定されていません. 設定のうえ、再試行してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1496"/>
+        <location filename="../moluscedialog.py" line="1691"/>
         <source>Cramer&apos;s Coefficient</source>
         <translation>Cramer係数</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="548"/>
+        <location filename="../moluscedialog.py" line="716"/>
         <source>Initial or final raster is not set. Please specify input data and try again</source>
         <translation>時期1あるいは時期2のラスターデータが設定されていません。インプットデータを設定のうえ、再試行してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Initial raster is not set. Please specify it and try again</source>
         <translation>時期1のラスターデータが設定されていません。設定のうえ、再試行してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="943"/>
+        <location filename="../moluscedialog.py" line="1137"/>
         <source>Simulation process is finished</source>
         <translation>シミュレーション・プロセスを終了しました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1030"/>
+        <location filename="../moluscedialog.py" line="1224"/>
         <source>Validation process is finished</source>
         <translation>検証プロセスを終了しました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1144"/>
+        <location filename="../moluscedialog.py" line="1338"/>
         <source>Save validation map</source>
         <translation>検証図を保存</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="224"/>
+        <location filename="../moluscedialog.py" line="232"/>
         <source>Initial raster is not selected. Please specify input data and try again</source>
         <translation>時期1のラスターデータが設定されていません。インプットデータを設定のうえ、再試行してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometries of the rasters are matched!</source>
         <translation>ラスターデータのジオメトリが一致しました!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1406"/>
+        <location filename="../moluscedialog.py" line="1601"/>
         <source>Correlation checking</source>
         <translation>相関評価</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1710"/>
+        <location filename="../moluscedialog.py" line="1905"/>
         <source>Multi Criteria Evaluation</source>
         <translation>マルチクライテリア評価</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Missed model</source>
         <translation>モデルが不足しています</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="493"/>
+        <location filename="../moluscedialog.py" line="661"/>
         <source>Memory Error occurred (correlation checking). Perhaps the system is low on memory.</source>
         <translation>メモリエラーが起きました (相関性の確認). おそらくシステムメモリが不足しています.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="363"/>
+        <location filename="../moluscedialog.py" line="431"/>
         <source>Memory Error occurred (loading raster %s). Perhaps the system is low on memory.</source>
         <translation>メモリエラーが起きました (ラスターデータのロード %s). おそらくシステムメモリが不足しています.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1282"/>
+        <location filename="../moluscedialog.py" line="1477"/>
         <source>raster units</source>
         <translation>ラスターデータの単位</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1871"/>
+        <location filename="../moluscedialog.py" line="2066"/>
         <source>An unknown error occurs during validation procedure</source>
         <translation>検証処理において未知のエラーが発生しています</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1705"/>
+        <location filename="../moluscedialog.py" line="1900"/>
         <source>Weights of Evidence</source>
         <translation>証拠の重み</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1202"/>
+        <location filename="../moluscedialog.py" line="1396"/>
         <source>Process of Validation Map creating is started</source>
         <translation>検証図作成プロセスを開始しました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1521"/>
+        <location filename="../moluscedialog.py" line="1716"/>
         <source>Not applicable</source>
         <translation>適用できません</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="461"/>
+        <location filename="../moluscedialog.py" line="573"/>
         <source>Geometries of the initial raster and final raster are different!</source>
         <translation>時期1のラスターデータと時期2ラスターデータのジオメトリが異なっています!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1695"/>
+        <location filename="../moluscedialog.py" line="1890"/>
         <source>Logistic Regression</source>
         <translation>ロジスティック回帰</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Transition potentials not implemented yet for the model.</source>
         <translation>モデルに対して遷移ポテンシャルが実行されていません.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1597"/>
+        <location filename="../moluscedialog.py" line="1792"/>
         <source>Class color</source>
         <translation>クラス色</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="816"/>
+        <location filename="../moluscedialog.py" line="1010"/>
         <source>Simulation process is started</source>
         <translation>シミュレーション・プロセスを開始しました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1299"/>
+        <location filename="../moluscedialog.py" line="1494"/>
         <source>Random</source>
         <translation>ランダム</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="326"/>
+        <location filename="../moluscedialog.py" line="394"/>
         <source>Factor raster is not selected. Please specify input data and try again</source>
         <translation>因子ラスターデータが設定されていません。インプットデータを設定のうえ、再試行してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1511"/>
+        <location filename="../moluscedialog.py" line="1706"/>
         <source>Joint Information Uncertainty</source>
         <translation>結合情報の不確実性</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="542"/>
+        <location filename="../moluscedialog.py" line="710"/>
         <source>Class statistics and transition matrix are updated</source>
         <translation>クラス統計と遷移行列が更新されました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1152"/>
+        <location filename="../moluscedialog.py" line="1346"/>
         <source>No file selected</source>
         <translation>ファイルが選択されていません</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Missed input data</source>
         <translation>インプットデータが不足しています</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file</source>
         <translation>ファイルが読めません</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1898"/>
+        <location filename="../moluscedialog.py" line="2093"/>
         <source>Can&apos;t load raster %s</source>
         <translation>ラスターデータ %sをロードできません</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable</source>
         <translation>Kappaは適用できません</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometry is matched</source>
         <translation>ジオメトリが一致しました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1486"/>
+        <location filename="../moluscedialog.py" line="1681"/>
         <source>Pearson&apos;s Correlation</source>
         <translation>ピアソン相関</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1700"/>
+        <location filename="../moluscedialog.py" line="1895"/>
         <source>Artificial Neural Network (Multi-layer Perceptron)</source>
         <translation>人工ニューラルネットワーク (Multi-layer Perceptron)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Nothing to save, samples were not yet generated as the model was not trained. Train the model first.</source>
         <translation>保存するファイルはありません。モデルのトレーニングが済んでいないため、サンプルを生成できません。事前にモデルのトレーニングをしてください。</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="902"/>
+        <location filename="../moluscedialog.py" line="1096"/>
         <source>Output path for simulated risk map is not set. Skipping this step</source>
         <translation>リスク・シミュレーション図の出力パスが設定されていません。このステップをスキップしてください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Different geometry</source>
         <translation>ジオメトリが異なっています</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="557"/>
+        <location filename="../moluscedialog.py" line="725"/>
         <source>Save change map</source>
         <translation>変化図を保存</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1300"/>
+        <location filename="../moluscedialog.py" line="1495"/>
         <source>Stratified</source>
         <translation>層化</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="361"/>
+        <location filename="../moluscedialog.py" line="369"/>
         <source>Added factor layer %s</source>
         <translation>因子レイヤー %sが追加されました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1111"/>
+        <location filename="../moluscedialog.py" line="1305"/>
         <source>Kappa validation process is finished</source>
         <translation>Kappa検証プロセスを終了しました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1308"/>
+        <location filename="../moluscedialog.py" line="1503"/>
         <source>Multiple-resolution budget</source>
         <translation>Multiple-resolution budget</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Missed selected row</source>
         <translation>行が未選択です</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Missed samples</source>
         <translation>サンプルが不足しています</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="176"/>
+        <location filename="../moluscedialog.py" line="184"/>
         <source>Start logging</source>
         <translation>ログ記録を開始します</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2066"/>
+        <location filename="../moluscedialog.py" line="2261"/>
         <source>Persistent</source>
         <translation>持続的</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1547"/>
+        <location filename="../moluscedialog.py" line="1742"/>
         <source>sq. km.</source>
         <translation>平方 km.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="615"/>
+        <location filename="../moluscedialog.py" line="783"/>
         <source>Change Map is created</source>
         <translation>変化図が作成されました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1813"/>
+        <location filename="../moluscedialog.py" line="2008"/>
         <source>Select Directory name</source>
         <translation>ディレクトリ名を選択してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="852"/>
+        <location filename="../moluscedialog.py" line="1046"/>
         <source>Output path for risk function map is not set. Skipping this step</source>
         <translation>リスク関数図の出力パスが設定されていません。このステップをスキップしてください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>Open file</source>
         <translation>ファイルを開きます</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="296"/>
+        <location filename="../moluscedialog.py" line="304"/>
         <source>Set final layer to %s</source>
         <translation>最終レイヤーを %sに設定してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1819"/>
+        <location filename="../moluscedialog.py" line="2014"/>
         <source>Save file</source>
         <translation>ファイルを保存</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file</source>
         <translation>ファイルを保存できません</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="427"/>
+        <location filename="../moluscedialog.py" line="527"/>
         <source>Factors list cleared</source>
         <translation>因子リストがクリアされました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error occurred. Perhaps the system is low on memory.</source>
         <translation>メモリエラーが起きました. おそらくシステムメモリが不足しています.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Can&apos;t open file</source>
         <translation>ファイルを開けません</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="772"/>
+        <location filename="../moluscedialog.py" line="964"/>
         <source>Factors rasters is not set. Please specify them and try again</source>
         <translation>因子ラスターデータが設定されていません。設定のうえ、再試行してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="988"/>
+        <location filename="../moluscedialog.py" line="1182"/>
         <source>Validation process is started</source>
         <translation>検証プロセスを開始しました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Missed transition matrix</source>
         <translation>遷移行列が不足しています</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1092"/>
+        <location filename="../moluscedialog.py" line="1286"/>
         <source>Kappa validation process is started</source>
         <translation>Kappa検証プロセスを開始しました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error</source>
         <translation>メモリエラー</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="413"/>
+        <location filename="../moluscedialog.py" line="480"/>
         <source>Removed factor layer %s</source>
         <translation>因子レイヤー %sが削除されました</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Please calculate transition matrix and try again</source>
         <translation>遷移行列を計算のうえ、再試行してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Not implemented yet</source>
         <translation>まだ実行されていません</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1758"/>
+        <location filename="../moluscedialog.py" line="1953"/>
         <source>Shape files (*.shp *.SHP *.Shp)</source>
         <translation>シェープファイル (*.shp *.SHP *.Shp)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="278"/>
+        <location filename="../moluscedialog.py" line="286"/>
         <source>Final raster is not selected. Please specify input data and try again</source>
         <translation>最終ラスターデータが設定されていません。インプットデータを設定のうえ、再試行してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</source>
         <translation>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>Raster must store codes of a nominal variable</source>
         <translation>ラスターはノミナル変数のコードを格納しなければならない</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>The raster has a lot of different values. Does the raster store a nominal variable?</source>
         <translation>ラスターには多くの異なる値がある。ラスターは公称変数を保存していますか？</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="452"/>
+        <location filename="../moluscedialog.py" line="618"/>
         <source>Geometries of the initial raster and raster &apos;{}&apos; are different!</source>
         <translation>初期ラスタとラスタ'{}'のジオメトリが異なる！</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file: &apos;{}&apos;</source>
         <translation>ファイルを読み込めません： '{}'</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file: &apos;{}&apos;</source>
         <translation>ファイルを保存できません： '{}'</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Error loading output shapefile:
 {}</source>
         <translation>出力ファイルの読み込み中にエラーが発生しました：
 {}</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Factor raster is not selected. Please specify it and try again</source>
         <translation>ファクターラスターが選択されていません。指定してからやり直してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="782"/>
+        <location filename="../moluscedialog.py" line="976"/>
         <source>Model not selected. Please select and train model.</source>
         <translation>モデルが選択されていません。モデルを選択してトレーニングしてください。</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable to the file: &apos;{}&apos; because it contains continuous value</source>
         <translation>Kappaはファイルには適用されない： '{}' は連続的な値を含んでいるため適用できない</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Selected model doesn&apos;t use samples</source>
         <translation>選択モデルはサンプルを使用しない</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1864"/>
+        <location filename="../moluscedialog.py" line="2059"/>
         <source>The system is out of memory during validation procedure</source>
         <translation>検証手順中にシステムがメモリ不足になった</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1539"/>
+        <location filename="../moluscedialog.py" line="1734"/>
         <source>metre</source>
         <translation>米</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1540"/>
+        <location filename="../moluscedialog.py" line="1735"/>
         <source>meter</source>
         <translation>米</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1541"/>
+        <location filename="../moluscedialog.py" line="1736"/>
         <source>meters</source>
         <translation>米</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1542"/>
+        <location filename="../moluscedialog.py" line="1737"/>
         <source>metres</source>
         <translation>米</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1543"/>
+        <location filename="../moluscedialog.py" line="1738"/>
         <source>unknown</source>
         <translation>不明</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 perfect quantity inform.</source>
         <translation>理想的なポジション情報のレベル,
 理想的な情報量のレベル.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 no quantity inform.</source>
         <translation>ポジションに関する情報なし,
 数量情報なし.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 medium quantity inform.</source>
         <translation>ポジションに関する情報なし,
 数量に関する中程度の情報.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Medium location,
 medium quantity inform.</source>
         <translation>状況に関する情報の平均レベル,
 数量に関する中程度の情報.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 medium quantity inform.</source>
         <translation>理想的なポジション情報のレベル,
 数量に関する中程度の情報.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="243"/>
+        <location filename="../moluscedialog.py" line="251"/>
         <source>Set initial layer to %s</source>
         <translation>初期レイヤーを %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1230"/>
+        <location filename="../moluscedialog.py" line="1424"/>
         <source>Process of Validation Map creating is finished</source>
         <translation>バリデーション・マップの作成が終了</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>File &apos;{}&apos; is used in the QGIS project. It is not possible to overwrite the file, specify a different file name and try again</source>
         <translation>ファイル '{}' が QGIS プロジェクトで使用されています。ファイルを上書きすることはできませんので、別のファイル名を指定して再試行してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="642"/>
+        <location filename="../moluscedialog.py" line="810"/>
         <source>Directory of transition potential maps is not set. Please specify it and try again</source>
         <translation>トランジションポテンシャルマップのディレクトリが設定されていません。指定してやり直してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Overwrite file</source>
         <translation>ファイルの上書き</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Files with the specified prefix already exist in this directory. This may cause the files to be overwritten. Are you sure you want to continue?</source>
         <translation>指定された接頭辞を持つファイルは、すでにこのディレクトリに存在する。ファイルが上書きされる可能性があります。本当に続けますか？</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="742"/>
+        <location filename="../moluscedialog.py" line="910"/>
         <source>Can&apos;t save file in the specified path &apos;{}&apos;. Please specify output path correctly and try again</source>
         <translation>指定されたパス '{}' にファイルを保存できません。出力パスを正しく指定して再試行してください</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Different characteristics of rasters</source>
         <translation>ラスターのさまざまな特徴</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Characteristics of the reference and simulated rasters are different!</source>
         <translation>リファレンス・ラスタとシミュレーション・ラスタの特性は異なる！</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Geometries of the reference and simulated rasters are different!</source>
         <translation>基準ラスタとシミュレートされたラスタの形状は異なる！</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2018"/>
+        <location filename="../moluscedialog.py" line="2213"/>
         <source>Init raster should be in PseudoColor or Paletted mode. Style not applied.</source>
         <translation>InitラスターはPseudoColorまたはPalettedモードでなければならない。スタイルは適用されない。</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>Can&apos;t rewrite file</source>
         <translation>ファイルの書き換えができない</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="761"/>
+        <location filename="../moluscedialog.py" line="929"/>
         <source>Can&apos;t save files with the same output path &apos;{}&apos;. Please specify different output paths and try again</source>
         <translation>同じ出力パス '{}' を持つファイルを保存できません。異なる出力パスを指定して再試行してください</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="429"/>
+        <source>Added factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="513"/>
+        <source>Removed factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="539"/>
+        <source>Factors list (sim) cleared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Different number of variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Model is trained using {} variables, and simulation was set up with {} variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Different number of bands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Training variable {} and simulation variable {} have different number of bands, {} and {} respectively</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Consistancy is checked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Training variables and Simulation variables are matched!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="941"/>
+        <source>Factors rasters for simulation are not set. Please specify them and try again, or disable their usage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="951"/>
+        <source>Separate variables version consistency is not checked</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -974,17 +1029,17 @@ medium quantity inform.</source>
         <translation>時期2 &gt;&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="105"/>
+        <location filename="../ui/moluscedialogbase.ui" line="638"/>
         <source>&lt;&lt; Remove all</source>
         <translation>&lt;&lt; 全て削除</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="112"/>
+        <location filename="../ui/moluscedialogbase.ui" line="631"/>
         <source>&lt;&lt; Remove</source>
         <translation>&lt;&lt; 削除</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="119"/>
+        <location filename="../ui/moluscedialogbase.ui" line="611"/>
         <source>Add &gt;&gt;</source>
         <translation>追加 &gt;&gt;</translation>
     </message>
@@ -1094,22 +1149,22 @@ medium quantity inform.</source>
         <translation>セルラーオートマタ・シミュレーション</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="725"/>
+        <location filename="../ui/moluscedialogbase.ui" line="797"/>
         <source>Browse...</source>
         <translation>開く...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="574"/>
+        <location filename="../ui/moluscedialogbase.ui" line="540"/>
         <source>Certainty function</source>
         <translation>予報の信頼度マップ</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="554"/>
+        <location filename="../ui/moluscedialogbase.ui" line="564"/>
         <source>Simulation result</source>
         <translation>シミュレーション結果</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="540"/>
+        <location filename="../ui/moluscedialogbase.ui" line="550"/>
         <source>Number of simulation iterations</source>
         <translation>シミュレーションの反復回数</translation>
     </message>
@@ -1119,77 +1174,77 @@ medium quantity inform.</source>
         <translation>potential_</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="620"/>
+        <location filename="../ui/moluscedialogbase.ui" line="692"/>
         <source>Start</source>
         <translation>スタート</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="643"/>
+        <location filename="../ui/moluscedialogbase.ui" line="715"/>
         <source>Validation</source>
         <translation>検証</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="683"/>
+        <location filename="../ui/moluscedialogbase.ui" line="755"/>
         <source>Create...</source>
         <translation>作成...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="690"/>
+        <location filename="../ui/moluscedialogbase.ui" line="762"/>
         <source>Validation Map</source>
         <translation>検証図</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="697"/>
+        <location filename="../ui/moluscedialogbase.ui" line="769"/>
         <source>Simulated Map</source>
         <translation>シミュレーション図</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="711"/>
+        <location filename="../ui/moluscedialogbase.ui" line="783"/>
         <source>Reference Map</source>
         <translation>参照図</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="752"/>
+        <location filename="../ui/moluscedialogbase.ui" line="824"/>
         <source>Number of validation iterations</source>
         <translation>検証反復数</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="759"/>
+        <location filename="../ui/moluscedialogbase.ui" line="831"/>
         <source>Check persistent classes</source>
         <translation>持続的なクラスの確認</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="785"/>
+        <location filename="../ui/moluscedialogbase.ui" line="857"/>
         <source>% of Correctness</source>
         <translation>精度（%）</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="857"/>
+        <location filename="../ui/moluscedialogbase.ui" line="929"/>
         <source>Calculate kappa</source>
         <translation>Kappaを計算</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="864"/>
+        <location filename="../ui/moluscedialogbase.ui" line="936"/>
         <source>Start validation</source>
         <translation>検証する</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="874"/>
+        <location filename="../ui/moluscedialogbase.ui" line="946"/>
         <source>Messages</source>
         <translation>メッセージ</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="811"/>
+        <location filename="../ui/moluscedialogbase.ui" line="883"/>
         <source>Kappa (overall)</source>
         <translation>Kappa （総合）</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="837"/>
+        <location filename="../ui/moluscedialogbase.ui" line="909"/>
         <source>Kappa (histogram)</source>
         <translation>Kappa （ヒストグラム）</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="850"/>
+        <location filename="../ui/moluscedialogbase.ui" line="922"/>
         <source>Kappa (location)</source>
         <translation>Kappa （場所）</translation>
     </message>
@@ -1212,6 +1267,16 @@ medium quantity inform.</source>
         <location filename="../ui/moluscedialogbase.ui" line="484"/>
         <source>Select Directory...</source>
         <translation>ディレクトリを選択...</translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="596"/>
+        <source>Set separate spatial variables version for simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="645"/>
+        <source>Check consistency</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/molusce/i18n/molusce_lang_LANG.ts
+++ b/src/molusce/i18n/molusce_lang_LANG.ts
@@ -403,544 +403,599 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MolusceDialog</name>
     <message>
-        <location filename="../moluscedialog.py" line="176"/>
+        <location filename="../moluscedialog.py" line="184"/>
         <source>Start logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Missed selected row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="224"/>
+        <location filename="../moluscedialog.py" line="232"/>
         <source>Initial raster is not selected. Please specify input data and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="363"/>
+        <location filename="../moluscedialog.py" line="431"/>
         <source>Memory Error occurred (loading raster %s). Perhaps the system is low on memory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="278"/>
+        <location filename="../moluscedialog.py" line="286"/>
         <source>Final raster is not selected. Please specify input data and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="296"/>
+        <location filename="../moluscedialog.py" line="304"/>
         <source>Set final layer to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="326"/>
+        <location filename="../moluscedialog.py" line="394"/>
         <source>Factor raster is not selected. Please specify input data and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="361"/>
+        <location filename="../moluscedialog.py" line="369"/>
         <source>Added factor layer %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error occurred. Perhaps the system is low on memory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="413"/>
+        <location filename="../moluscedialog.py" line="480"/>
         <source>Removed factor layer %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="427"/>
+        <location filename="../moluscedialog.py" line="527"/>
         <source>Factors list cleared</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Missed input data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="772"/>
+        <location filename="../moluscedialog.py" line="964"/>
         <source>Factors rasters is not set. Please specify them and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="548"/>
+        <location filename="../moluscedialog.py" line="716"/>
         <source>Initial or final raster is not set. Please specify input data and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Different geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="461"/>
+        <location filename="../moluscedialog.py" line="573"/>
         <source>Geometries of the initial raster and final raster are different!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometry is matched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometries of the rasters are matched!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="493"/>
+        <location filename="../moluscedialog.py" line="661"/>
         <source>Memory Error occurred (correlation checking). Perhaps the system is low on memory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="542"/>
+        <location filename="../moluscedialog.py" line="710"/>
         <source>Class statistics and transition matrix are updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="557"/>
+        <location filename="../moluscedialog.py" line="725"/>
         <source>Save change map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1152"/>
+        <location filename="../moluscedialog.py" line="1346"/>
         <source>No file selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="615"/>
+        <location filename="../moluscedialog.py" line="783"/>
         <source>Change Map is created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Initial raster is not set. Please specify it and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="632"/>
+        <location filename="../moluscedialog.py" line="800"/>
         <source>Prefix of transition potential maps is not set. Please specify it and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Missed model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Missed transition matrix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Please calculate transition matrix and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="816"/>
+        <location filename="../moluscedialog.py" line="1010"/>
         <source>Simulation process is started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="852"/>
+        <location filename="../moluscedialog.py" line="1046"/>
         <source>Output path for risk function map is not set. Skipping this step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="902"/>
+        <location filename="../moluscedialog.py" line="1096"/>
         <source>Output path for simulated risk map is not set. Skipping this step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Not implemented yet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Transition potentials not implemented yet for the model.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="943"/>
+        <location filename="../moluscedialog.py" line="1137"/>
         <source>Simulation process is finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="988"/>
+        <location filename="../moluscedialog.py" line="1182"/>
         <source>Validation process is started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1030"/>
+        <location filename="../moluscedialog.py" line="1224"/>
         <source>Validation process is finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1092"/>
+        <location filename="../moluscedialog.py" line="1286"/>
         <source>Kappa validation process is started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1111"/>
+        <location filename="../moluscedialog.py" line="1305"/>
         <source>Kappa validation process is finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1144"/>
+        <location filename="../moluscedialog.py" line="1338"/>
         <source>Save validation map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1202"/>
+        <location filename="../moluscedialog.py" line="1396"/>
         <source>Process of Validation Map creating is started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1486"/>
+        <location filename="../moluscedialog.py" line="1681"/>
         <source>Pearson&apos;s Correlation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1496"/>
+        <location filename="../moluscedialog.py" line="1691"/>
         <source>Cramer&apos;s Coefficient</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1511"/>
+        <location filename="../moluscedialog.py" line="1706"/>
         <source>Joint Information Uncertainty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1282"/>
+        <location filename="../moluscedialog.py" line="1477"/>
         <source>raster units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1547"/>
+        <location filename="../moluscedialog.py" line="1742"/>
         <source>sq. km.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1549"/>
+        <location filename="../moluscedialog.py" line="1744"/>
         <source>ha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1700"/>
+        <location filename="../moluscedialog.py" line="1895"/>
         <source>Artificial Neural Network (Multi-layer Perceptron)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1705"/>
+        <location filename="../moluscedialog.py" line="1900"/>
         <source>Weights of Evidence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1710"/>
+        <location filename="../moluscedialog.py" line="1905"/>
         <source>Multi Criteria Evaluation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1695"/>
+        <location filename="../moluscedialog.py" line="1890"/>
         <source>Logistic Regression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1298"/>
+        <location filename="../moluscedialog.py" line="1493"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1299"/>
+        <location filename="../moluscedialog.py" line="1494"/>
         <source>Random</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1300"/>
+        <location filename="../moluscedialog.py" line="1495"/>
         <source>Stratified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1308"/>
+        <location filename="../moluscedialog.py" line="1503"/>
         <source>Multiple-resolution budget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1406"/>
+        <location filename="../moluscedialog.py" line="1601"/>
         <source>Correlation checking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1521"/>
+        <location filename="../moluscedialog.py" line="1716"/>
         <source>Not applicable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1553"/>
+        <location filename="../moluscedialog.py" line="1748"/>
         <source>sq. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1597"/>
+        <location filename="../moluscedialog.py" line="1792"/>
         <source>Class color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Nothing to save, samples were not yet generated as the model was not trained. Train the model first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Missed samples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1819"/>
+        <location filename="../moluscedialog.py" line="2014"/>
         <source>Save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1758"/>
+        <location filename="../moluscedialog.py" line="1953"/>
         <source>Shape files (*.shp *.SHP *.Shp)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Can&apos;t open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1813"/>
+        <location filename="../moluscedialog.py" line="2008"/>
         <source>Select Directory name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1871"/>
+        <location filename="../moluscedialog.py" line="2066"/>
         <source>An unknown error occurs during validation procedure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1898"/>
+        <location filename="../moluscedialog.py" line="2093"/>
         <source>Can&apos;t load raster %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2066"/>
+        <location filename="../moluscedialog.py" line="2261"/>
         <source>Persistent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>Raster must store codes of a nominal variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>The raster has a lot of different values. Does the raster store a nominal variable?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="452"/>
+        <location filename="../moluscedialog.py" line="618"/>
         <source>Geometries of the initial raster and raster &apos;{}&apos; are different!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file: &apos;{}&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file: &apos;{}&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Error loading output shapefile:
 {}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Factor raster is not selected. Please specify it and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="782"/>
+        <location filename="../moluscedialog.py" line="976"/>
         <source>Model not selected. Please select and train model.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable to the file: &apos;{}&apos; because it contains continuous value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Selected model doesn&apos;t use samples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1864"/>
+        <location filename="../moluscedialog.py" line="2059"/>
         <source>The system is out of memory during validation procedure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1539"/>
+        <location filename="../moluscedialog.py" line="1734"/>
         <source>metre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1540"/>
+        <location filename="../moluscedialog.py" line="1735"/>
         <source>meter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1541"/>
+        <location filename="../moluscedialog.py" line="1736"/>
         <source>meters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1542"/>
+        <location filename="../moluscedialog.py" line="1737"/>
         <source>metres</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1543"/>
+        <location filename="../moluscedialog.py" line="1738"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 perfect quantity inform.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 no quantity inform.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 medium quantity inform.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Medium location,
 medium quantity inform.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 medium quantity inform.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="243"/>
+        <location filename="../moluscedialog.py" line="251"/>
         <source>Set initial layer to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1230"/>
+        <location filename="../moluscedialog.py" line="1424"/>
         <source>Process of Validation Map creating is finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>File &apos;{}&apos; is used in the QGIS project. It is not possible to overwrite the file, specify a different file name and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="642"/>
+        <location filename="../moluscedialog.py" line="810"/>
         <source>Directory of transition potential maps is not set. Please specify it and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Overwrite file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Files with the specified prefix already exist in this directory. This may cause the files to be overwritten. Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="742"/>
+        <location filename="../moluscedialog.py" line="910"/>
         <source>Can&apos;t save file in the specified path &apos;{}&apos;. Please specify output path correctly and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Different characteristics of rasters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Characteristics of the reference and simulated rasters are different!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Geometries of the reference and simulated rasters are different!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2018"/>
+        <location filename="../moluscedialog.py" line="2213"/>
         <source>Init raster should be in PseudoColor or Paletted mode. Style not applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>Can&apos;t rewrite file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="761"/>
+        <location filename="../moluscedialog.py" line="929"/>
         <source>Can&apos;t save files with the same output path &apos;{}&apos;. Please specify different output paths and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="429"/>
+        <source>Added factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="513"/>
+        <source>Removed factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="539"/>
+        <source>Factors list (sim) cleared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Different number of variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Model is trained using {} variables, and simulation was set up with {} variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Different number of bands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Training variable {} and simulation variable {} have different number of bands, {} and {} respectively</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Consistancy is checked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Training variables and Simulation variables are matched!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="941"/>
+        <source>Factors rasters for simulation are not set. Please specify them and try again, or disable their usage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="951"/>
+        <source>Separate variables version consistency is not checked</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -967,17 +1022,17 @@ medium quantity inform.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="105"/>
+        <location filename="../ui/moluscedialogbase.ui" line="638"/>
         <source>&lt;&lt; Remove all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="112"/>
+        <location filename="../ui/moluscedialogbase.ui" line="631"/>
         <source>&lt;&lt; Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="119"/>
+        <location filename="../ui/moluscedialogbase.ui" line="611"/>
         <source>Add &gt;&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1087,22 +1142,22 @@ medium quantity inform.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="725"/>
+        <location filename="../ui/moluscedialogbase.ui" line="797"/>
         <source>Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="574"/>
+        <location filename="../ui/moluscedialogbase.ui" line="540"/>
         <source>Certainty function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="554"/>
+        <location filename="../ui/moluscedialogbase.ui" line="564"/>
         <source>Simulation result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="540"/>
+        <location filename="../ui/moluscedialogbase.ui" line="550"/>
         <source>Number of simulation iterations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1112,77 +1167,77 @@ medium quantity inform.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="620"/>
+        <location filename="../ui/moluscedialogbase.ui" line="692"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="643"/>
+        <location filename="../ui/moluscedialogbase.ui" line="715"/>
         <source>Validation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="683"/>
+        <location filename="../ui/moluscedialogbase.ui" line="755"/>
         <source>Create...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="690"/>
+        <location filename="../ui/moluscedialogbase.ui" line="762"/>
         <source>Validation Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="697"/>
+        <location filename="../ui/moluscedialogbase.ui" line="769"/>
         <source>Simulated Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="711"/>
+        <location filename="../ui/moluscedialogbase.ui" line="783"/>
         <source>Reference Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="752"/>
+        <location filename="../ui/moluscedialogbase.ui" line="824"/>
         <source>Number of validation iterations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="759"/>
+        <location filename="../ui/moluscedialogbase.ui" line="831"/>
         <source>Check persistent classes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="785"/>
+        <location filename="../ui/moluscedialogbase.ui" line="857"/>
         <source>% of Correctness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="857"/>
+        <location filename="../ui/moluscedialogbase.ui" line="929"/>
         <source>Calculate kappa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="864"/>
+        <location filename="../ui/moluscedialogbase.ui" line="936"/>
         <source>Start validation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="874"/>
+        <location filename="../ui/moluscedialogbase.ui" line="946"/>
         <source>Messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="811"/>
+        <location filename="../ui/moluscedialogbase.ui" line="883"/>
         <source>Kappa (overall)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="837"/>
+        <location filename="../ui/moluscedialogbase.ui" line="909"/>
         <source>Kappa (histogram)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="850"/>
+        <location filename="../ui/moluscedialogbase.ui" line="922"/>
         <source>Kappa (location)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,6 +1259,16 @@ medium quantity inform.</source>
     <message>
         <location filename="../ui/moluscedialogbase.ui" line="484"/>
         <source>Select Directory...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="596"/>
+        <source>Set separate spatial variables version for simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="645"/>
+        <source>Check consistency</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/molusce/i18n/molusce_pt.ts
+++ b/src/molusce/i18n/molusce_pt.ts
@@ -404,551 +404,606 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MolusceDialog</name>
     <message>
-        <location filename="../moluscedialog.py" line="176"/>
+        <location filename="../moluscedialog.py" line="184"/>
         <source>Start logging</source>
         <translation>Iniciar o registo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Missed selected row</source>
         <translation>Objeto não selecionado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="224"/>
+        <location filename="../moluscedialog.py" line="232"/>
         <source>Initial raster is not selected. Please specify input data and try again</source>
         <translation>Nenhum raster de estado inicial especificado. Por favor, insira os dados de entrada e tente novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="363"/>
+        <location filename="../moluscedialog.py" line="431"/>
         <source>Memory Error occurred (loading raster %s). Perhaps the system is low on memory.</source>
         <translation>Ocorreu um erro de memória (carregando raster %s). Talvez o sistema esteja com pouca memória.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="278"/>
+        <location filename="../moluscedialog.py" line="286"/>
         <source>Final raster is not selected. Please specify input data and try again</source>
         <translation>Nenhum raster de estado final especificado. Por favor, insira os dados de entrada e tente novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="296"/>
+        <location filename="../moluscedialog.py" line="304"/>
         <source>Set final layer to %s</source>
         <translation>Definir a camada final como %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="326"/>
+        <location filename="../moluscedialog.py" line="394"/>
         <source>Factor raster is not selected. Please specify input data and try again</source>
         <translation>Não há mapa de influência. Por favor, insira os dados de entrada e tente novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="361"/>
+        <location filename="../moluscedialog.py" line="369"/>
         <source>Added factor layer %s</source>
         <translation>Adicionado mapa de influência do fator %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error</source>
         <translation>Erro de memória</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error occurred. Perhaps the system is low on memory.</source>
         <translation>Ocorreu um erro de memória. Pode não haver memória suficiente no sistema.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="413"/>
+        <location filename="../moluscedialog.py" line="480"/>
         <source>Removed factor layer %s</source>
         <translation>Eliminado mapa de influência do fator %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="427"/>
+        <location filename="../moluscedialog.py" line="527"/>
         <source>Factors list cleared</source>
         <translation>Lista de fatores de influência limpa</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Missed input data</source>
         <translation>Nenhum conjunto de dados de entrada</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="772"/>
+        <location filename="../moluscedialog.py" line="964"/>
         <source>Factors rasters is not set. Please specify them and try again</source>
         <translation>Não há mapas de influência de fatores. Por favor, forneça mapas de influência e tente novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="548"/>
+        <location filename="../moluscedialog.py" line="716"/>
         <source>Initial or final raster is not set. Please specify input data and try again</source>
         <translation>Nenhum raster de estado inicial ou final foi especificado. Por favor, insira os dados de entrada e tente novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Different geometry</source>
         <translation>Características espaciais que não se sobrepõem</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="461"/>
+        <location filename="../moluscedialog.py" line="573"/>
         <source>Geometries of the initial raster and final raster are different!</source>
         <translation>As características espaciais dos traçados dos estados inicial e final não coincidem!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometry is matched</source>
         <translation>As características espaciais coincidem</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometries of the rasters are matched!</source>
         <translation>As características espaciais dos rastros coincidem!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="493"/>
+        <location filename="../moluscedialog.py" line="661"/>
         <source>Memory Error occurred (correlation checking). Perhaps the system is low on memory.</source>
         <translation>Ocorreu um erro de memória (cálculo de correlação). Pode não haver memória suficiente no sistema.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="542"/>
+        <location filename="../moluscedialog.py" line="710"/>
         <source>Class statistics and transition matrix are updated</source>
         <translation>Tabela de estatísticas de classe e matriz de transições atualizadas</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="557"/>
+        <location filename="../moluscedialog.py" line="725"/>
         <source>Save change map</source>
         <translation>Guardar o mapa de alterações</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</source>
         <translation>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1152"/>
+        <location filename="../moluscedialog.py" line="1346"/>
         <source>No file selected</source>
         <translation>Ficheiro não selecionado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="615"/>
+        <location filename="../moluscedialog.py" line="783"/>
         <source>Change Map is created</source>
         <translation>Mapa de alterações criado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Initial raster is not set. Please specify it and try again</source>
         <translation>Nenhum raster de estado inicial especificado. Por favor, insira o raster dos estados iniciais e tente novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="632"/>
+        <location filename="../moluscedialog.py" line="800"/>
         <source>Prefix of transition potential maps is not set. Please specify it and try again</source>
         <translation>O prefixo do ficheiro para os mapas de potencial de transição não foi especificado. Por favor, especifique um prefixo e tente novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Missed model</source>
         <translation>Modelo não especificado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Missed transition matrix</source>
         <translation>Matriz de transição não calculada</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Please calculate transition matrix and try again</source>
         <translation>Por favor, calcule a matriz de transições e tente novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="816"/>
+        <location filename="../moluscedialog.py" line="1010"/>
         <source>Simulation process is started</source>
         <translation>Processo de simulação iniciado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="852"/>
+        <location filename="../moluscedialog.py" line="1046"/>
         <source>Output path for risk function map is not set. Skipping this step</source>
         <translation>Não está definido nenhum caminho de gravação para o mapa de confiança da previsão. Ignorar este passo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="902"/>
+        <location filename="../moluscedialog.py" line="1096"/>
         <source>Output path for simulated risk map is not set. Skipping this step</source>
         <translation>Não foi especificado o caminho de gravação para o mapa de previsão de alterações. Ignorar este passo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Not implemented yet</source>
         <translation>Mapas de potencial de transição não implementados</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Transition potentials not implemented yet for the model.</source>
         <translation>Os mapas de potencial de transição para este modelo ainda não foram implementados.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="943"/>
+        <location filename="../moluscedialog.py" line="1137"/>
         <source>Simulation process is finished</source>
         <translation>Processo de simulação concluído</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file</source>
         <translation>Não é possível ler o ficheiro</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="988"/>
+        <location filename="../moluscedialog.py" line="1182"/>
         <source>Validation process is started</source>
         <translation>Processo de validação iniciado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1030"/>
+        <location filename="../moluscedialog.py" line="1224"/>
         <source>Validation process is finished</source>
         <translation>Processo de validação concluído</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable</source>
         <translation>Kappa não é aplicável</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1092"/>
+        <location filename="../moluscedialog.py" line="1286"/>
         <source>Kappa validation process is started</source>
         <translation>O processo de validação kappa é iniciado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1111"/>
+        <location filename="../moluscedialog.py" line="1305"/>
         <source>Kappa validation process is finished</source>
         <translation>O processo de validação kappa está concluído</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1144"/>
+        <location filename="../moluscedialog.py" line="1338"/>
         <source>Save validation map</source>
         <translation>Guardar o mapa de erros</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1202"/>
+        <location filename="../moluscedialog.py" line="1396"/>
         <source>Process of Validation Map creating is started</source>
         <translation>O processo de cálculo do mapa de erros foi iniciado</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1486"/>
+        <location filename="../moluscedialog.py" line="1681"/>
         <source>Pearson&apos;s Correlation</source>
         <translation>Correlação de Pearson</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1496"/>
+        <location filename="../moluscedialog.py" line="1691"/>
         <source>Cramer&apos;s Coefficient</source>
         <translation>Coeficiente de Cramer</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1511"/>
+        <location filename="../moluscedialog.py" line="1706"/>
         <source>Joint Information Uncertainty</source>
         <translation>Coeficiente JIU (incerteza total da informação)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1282"/>
+        <location filename="../moluscedialog.py" line="1477"/>
         <source>raster units</source>
         <translation>unidades de raster</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1547"/>
+        <location filename="../moluscedialog.py" line="1742"/>
         <source>sq. km.</source>
         <translation>km²</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1549"/>
+        <location filename="../moluscedialog.py" line="1744"/>
         <source>ha</source>
         <translation>ha</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1700"/>
+        <location filename="../moluscedialog.py" line="1895"/>
         <source>Artificial Neural Network (Multi-layer Perceptron)</source>
         <translation>Redes neuronais (perceptron multicamada)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1705"/>
+        <location filename="../moluscedialog.py" line="1900"/>
         <source>Weights of Evidence</source>
         <translation>Significado da caraterística</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1710"/>
+        <location filename="../moluscedialog.py" line="1905"/>
         <source>Multi Criteria Evaluation</source>
         <translation>Avaliação multicritério</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1695"/>
+        <location filename="../moluscedialog.py" line="1890"/>
         <source>Logistic Regression</source>
         <translation>Regressão logística</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1298"/>
+        <location filename="../moluscedialog.py" line="1493"/>
         <source>All</source>
         <translation>Сompleta</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1299"/>
+        <location filename="../moluscedialog.py" line="1494"/>
         <source>Random</source>
         <translation>Aleatória</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1300"/>
+        <location filename="../moluscedialog.py" line="1495"/>
         <source>Stratified</source>
         <translation>Estratificada</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1308"/>
+        <location filename="../moluscedialog.py" line="1503"/>
         <source>Multiple-resolution budget</source>
         <translation>Magnitudes de erro em diferentes escalas espaciais</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1406"/>
+        <location filename="../moluscedialog.py" line="1601"/>
         <source>Correlation checking</source>
         <translation>Cálculo de correlação</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1521"/>
+        <location filename="../moluscedialog.py" line="1716"/>
         <source>Not applicable</source>
         <translation>Não aplicável</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1553"/>
+        <location filename="../moluscedialog.py" line="1748"/>
         <source>sq. </source>
         <translation>quadro. </translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1597"/>
+        <location filename="../moluscedialog.py" line="1792"/>
         <source>Class color</source>
         <translation>Cor da classe</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Nothing to save, samples were not yet generated as the model was not trained. Train the model first.</source>
         <translation>Não é possível guardar, ainda não foram gerados amostras porque o modelo não foi treinado. Treine o modelo primeiro.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Missed samples</source>
         <translation>Os amostras não estão definidos</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1819"/>
+        <location filename="../moluscedialog.py" line="2014"/>
         <source>Save file</source>
         <translation>Guardar ficheiro</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1758"/>
+        <location filename="../moluscedialog.py" line="1953"/>
         <source>Shape files (*.shp *.SHP *.Shp)</source>
         <translation>Shape files (*.shp *.SHP *.Shp)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file</source>
         <translation>Não é possível guardar o ficheiro</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Can&apos;t open file</source>
         <translation>Não é possível abrir o ficheiro</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1813"/>
+        <location filename="../moluscedialog.py" line="2008"/>
         <source>Select Directory name</source>
         <translation>Selecionar o nome do diretório</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>Open file</source>
         <translation>Abrir ficheiro</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1871"/>
+        <location filename="../moluscedialog.py" line="2066"/>
         <source>An unknown error occurs during validation procedure</source>
         <translation>Ocorreu um erro desconhecido durante o processo de validação</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1898"/>
+        <location filename="../moluscedialog.py" line="2093"/>
         <source>Can&apos;t load raster %s</source>
         <translation>Não é possível carregar o raster %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2066"/>
+        <location filename="../moluscedialog.py" line="2261"/>
         <source>Persistent</source>
         <translation>Persistente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>Raster must store codes of a nominal variable</source>
         <translation>Raster deve armazenar códigos de uma variável nominal</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>The raster has a lot of different values. Does the raster store a nominal variable?</source>
         <translation>O raster tem muitos valores diferentes. O raster armazena uma variável nominal?</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="452"/>
+        <location filename="../moluscedialog.py" line="618"/>
         <source>Geometries of the initial raster and raster &apos;{}&apos; are different!</source>
         <translation>As características espaciais dos rastros dos estados inicial e final '{} ' não coincidem!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file: &apos;{}&apos;</source>
         <translation>Não é possível ler o ficheiro: '{}'</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file: &apos;{}&apos;</source>
         <translation>Não é possível gravar o ficheiro: '{}'</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Error loading output shapefile:
 {}</source>
         <translation>Erro ao carregar o ficheiro de saída:
 {}</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Factor raster is not selected. Please specify it and try again</source>
         <translation>Não foi seleccionado nenhum mapa de influência. Por favor, forneça um mapa de influência e tente novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="782"/>
+        <location filename="../moluscedialog.py" line="976"/>
         <source>Model not selected. Please select and train model.</source>
         <translation>Modelo não selecionado. Por favor, escolha e ensine um modelo.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable to the file: &apos;{}&apos; because it contains continuous value</source>
         <translation>Kappa não é aplicável ao ficheiro: '{}' porque contém um valor contínuo</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Selected model doesn&apos;t use samples</source>
         <translation>O modelo selecionado não utiliza amostras</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1864"/>
+        <location filename="../moluscedialog.py" line="2059"/>
         <source>The system is out of memory during validation procedure</source>
         <translation>Ocorreu um estouro de memória durante o procedimento de validação</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1539"/>
+        <location filename="../moluscedialog.py" line="1734"/>
         <source>metre</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1540"/>
+        <location filename="../moluscedialog.py" line="1735"/>
         <source>meter</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1541"/>
+        <location filename="../moluscedialog.py" line="1736"/>
         <source>meters</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1542"/>
+        <location filename="../moluscedialog.py" line="1737"/>
         <source>metres</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1543"/>
+        <location filename="../moluscedialog.py" line="1738"/>
         <source>unknown</source>
         <translation>desconhecido</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 perfect quantity inform.</source>
         <translation>Nível ideal de informações de posição,
 nível ideal de informação de quantidade.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 no quantity inform.</source>
         <translation>Nenhuma informação sobre a posição,
 não há informações sobre a quantidade.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 medium quantity inform.</source>
         <translation>Nenhuma informação sobre a posição,
 nível médio de informação sobre a quantidade.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Medium location,
 medium quantity inform.</source>
         <translation>Nível médio de informação sobre a posição,
 nível médio de informação sobre a quantidade.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 medium quantity inform.</source>
         <translation>Nível ideal de informações de posição,
 nível médio de informação sobre a quantidade.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="243"/>
+        <location filename="../moluscedialog.py" line="251"/>
         <source>Set initial layer to %s</source>
         <translation>Definir a camada inicial como %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1230"/>
+        <location filename="../moluscedialog.py" line="1424"/>
         <source>Process of Validation Map creating is finished</source>
         <translation>Processo de cálculo do mapa de erros concluído</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>File &apos;{}&apos; is used in the QGIS project. It is not possible to overwrite the file, specify a different file name and try again</source>
         <translation>O ficheiro '{}' é utilizado no projeto QGIS. Não é possível substituir o ficheiro, é necessário especificar um nome de ficheiro diferente e tentar novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="642"/>
+        <location filename="../moluscedialog.py" line="810"/>
         <source>Directory of transition potential maps is not set. Please specify it and try again</source>
         <translation>O diretório dos mapas de potencial de transição não está definido. Especifique-o e tente novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Overwrite file</source>
         <translation>Substituir ficheiro</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Files with the specified prefix already exist in this directory. This may cause the files to be overwritten. Are you sure you want to continue?</source>
         <translation>Os ficheiros com o prefixo especificado já existem neste diretório. Isto pode fazer com que os ficheiros sejam substituídos. Tem a certeza de que pretende continuar?</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="742"/>
+        <location filename="../moluscedialog.py" line="910"/>
         <source>Can&apos;t save file in the specified path &apos;{}&apos;. Please specify output path correctly and try again</source>
         <translation>Não é possível guardar o ficheiro no caminho especificado '{}'. Especifique corretamente o caminho de saída e tente novamente</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Different characteristics of rasters</source>
         <translation>Diferentes características dos rasters</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Characteristics of the reference and simulated rasters are different!</source>
         <translation>As características dos traçados de referência e simulados são diferentes!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Geometries of the reference and simulated rasters are different!</source>
         <translation>As geometrias dos rasters de referência e simulados são diferentes!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2018"/>
+        <location filename="../moluscedialog.py" line="2213"/>
         <source>Init raster should be in PseudoColor or Paletted mode. Style not applied.</source>
         <translation>A rasterização inicial deve estar no modo PseudoColor ou Paletted. Estilo não aplicado.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>Can&apos;t rewrite file</source>
         <translation>Não é possível reescrever o ficheiro</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="761"/>
+        <location filename="../moluscedialog.py" line="929"/>
         <source>Can&apos;t save files with the same output path &apos;{}&apos;. Please specify different output paths and try again</source>
         <translation>Não é possível guardar ficheiros com o mesmo caminho de saída '{}'. Especifique caminhos de saída diferentes e tente novamente</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="429"/>
+        <source>Added factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="513"/>
+        <source>Removed factor (sim) layer %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="539"/>
+        <source>Factors list (sim) cleared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Different number of variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Model is trained using {} variables, and simulation was set up with {} variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Different number of bands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Training variable {} and simulation variable {} have different number of bands, {} and {} respectively</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Consistancy is checked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Training variables and Simulation variables are matched!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="941"/>
+        <source>Factors rasters for simulation are not set. Please specify them and try again, or disable their usage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="951"/>
+        <source>Separate variables version consistency is not checked</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -974,17 +1029,17 @@ nível médio de informação sobre a quantidade.</translation>
         <translation>Final &gt;&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="105"/>
+        <location filename="../ui/moluscedialogbase.ui" line="638"/>
         <source>&lt;&lt; Remove all</source>
         <translation>&lt;&lt; Remover tudo</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="112"/>
+        <location filename="../ui/moluscedialogbase.ui" line="631"/>
         <source>&lt;&lt; Remove</source>
         <translation>&lt;&lt; Remover</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="119"/>
+        <location filename="../ui/moluscedialogbase.ui" line="611"/>
         <source>Add &gt;&gt;</source>
         <translation>Adicionar &gt;&gt;</translation>
     </message>
@@ -1094,22 +1149,22 @@ nível médio de informação sobre a quantidade.</translation>
         <translation>Simulação de Autómatos Celulares</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="725"/>
+        <location filename="../ui/moluscedialogbase.ui" line="797"/>
         <source>Browse...</source>
         <translation>Navegar...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="574"/>
+        <location filename="../ui/moluscedialogbase.ui" line="540"/>
         <source>Certainty function</source>
         <translation>Mapa de previsão de confiança</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="554"/>
+        <location filename="../ui/moluscedialogbase.ui" line="564"/>
         <source>Simulation result</source>
         <translation>Resultado da simulação</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="540"/>
+        <location filename="../ui/moluscedialogbase.ui" line="550"/>
         <source>Number of simulation iterations</source>
         <translation>Número de iterações de simulação</translation>
     </message>
@@ -1119,77 +1174,77 @@ nível médio de informação sobre a quantidade.</translation>
         <translation>potential_</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="620"/>
+        <location filename="../ui/moluscedialogbase.ui" line="692"/>
         <source>Start</source>
         <translation>Início</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="643"/>
+        <location filename="../ui/moluscedialogbase.ui" line="715"/>
         <source>Validation</source>
         <translation>Validação</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="683"/>
+        <location filename="../ui/moluscedialogbase.ui" line="755"/>
         <source>Create...</source>
         <translation>Criar...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="690"/>
+        <location filename="../ui/moluscedialogbase.ui" line="762"/>
         <source>Validation Map</source>
         <translation>Mapa de erros</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="697"/>
+        <location filename="../ui/moluscedialogbase.ui" line="769"/>
         <source>Simulated Map</source>
         <translation>Mapa de resultados da simulação</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="711"/>
+        <location filename="../ui/moluscedialogbase.ui" line="783"/>
         <source>Reference Map</source>
         <translation>Mapa dos valores verdadeiros</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="752"/>
+        <location filename="../ui/moluscedialogbase.ui" line="824"/>
         <source>Number of validation iterations</source>
         <translation>Número de iterações de validação</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="759"/>
+        <location filename="../ui/moluscedialogbase.ui" line="831"/>
         <source>Check persistent classes</source>
         <translation>Calcular classes persistentes</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="785"/>
+        <location filename="../ui/moluscedialogbase.ui" line="857"/>
         <source>% of Correctness</source>
         <translation>% de correcção</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="857"/>
+        <location filename="../ui/moluscedialogbase.ui" line="929"/>
         <source>Calculate kappa</source>
         <translation>Calcular kappa</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="864"/>
+        <location filename="../ui/moluscedialogbase.ui" line="936"/>
         <source>Start validation</source>
         <translation>Iniciar validação</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="874"/>
+        <location filename="../ui/moluscedialogbase.ui" line="946"/>
         <source>Messages</source>
         <translation>Mensagens</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="811"/>
+        <location filename="../ui/moluscedialogbase.ui" line="883"/>
         <source>Kappa (overall)</source>
         <translation>Kappa (geral)</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="837"/>
+        <location filename="../ui/moluscedialogbase.ui" line="909"/>
         <source>Kappa (histogram)</source>
         <translation>Kappa (histograma)</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="850"/>
+        <location filename="../ui/moluscedialogbase.ui" line="922"/>
         <source>Kappa (location)</source>
         <translation>Kappa (posição)</translation>
     </message>
@@ -1212,6 +1267,16 @@ nível médio de informação sobre a quantidade.</translation>
         <location filename="../ui/moluscedialogbase.ui" line="484"/>
         <source>Select Directory...</source>
         <translation>Selecionar diretório...</translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="596"/>
+        <source>Set separate spatial variables version for simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="645"/>
+        <source>Check consistency</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/molusce/i18n/molusce_ru.ts
+++ b/src/molusce/i18n/molusce_ru.ts
@@ -404,551 +404,606 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MolusceDialog</name>
     <message>
-        <location filename="../moluscedialog.py" line="176"/>
+        <location filename="../moluscedialog.py" line="184"/>
         <source>Start logging</source>
         <translation>Начато ведение журнала сообщений</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Missed selected row</source>
         <translation>Объект не выбран</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="224"/>
+        <location filename="../moluscedialog.py" line="232"/>
         <source>Initial raster is not selected. Please specify input data and try again</source>
         <translation>Не задан растр начальных состояний. Пожалуйста, укажите входные данные и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="363"/>
+        <location filename="../moluscedialog.py" line="431"/>
         <source>Memory Error occurred (loading raster %s). Perhaps the system is low on memory.</source>
         <translation>Произошла ошибка памяти (загрузка растра %s). Возможно, в системе недостаточно памяти.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="278"/>
+        <location filename="../moluscedialog.py" line="286"/>
         <source>Final raster is not selected. Please specify input data and try again</source>
         <translation>Не задан растр конечных состояний. Пожалуйста, укажите входные данные и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="296"/>
+        <location filename="../moluscedialog.py" line="304"/>
         <source>Set final layer to %s</source>
         <translation>Установлен растр конечных состояний - %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="326"/>
+        <location filename="../moluscedialog.py" line="394"/>
         <source>Factor raster is not selected. Please specify input data and try again</source>
         <translation>Не задана карта влияния фактора. Пожалуйста, укажите входные данные и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="361"/>
+        <location filename="../moluscedialog.py" line="369"/>
         <source>Added factor layer %s</source>
         <translation>Добавлена карта влияния фактора - %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error</source>
         <translation>Ошибка памяти</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="369"/>
+        <location filename="../moluscedialog.py" line="437"/>
         <source>Memory error occurred. Perhaps the system is low on memory.</source>
         <translation>Произошла ошибка памяти. Возможно, в системе недостаточно памяти.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="413"/>
+        <location filename="../moluscedialog.py" line="480"/>
         <source>Removed factor layer %s</source>
         <translation>Удалена карта влияния фактора - %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="427"/>
+        <location filename="../moluscedialog.py" line="527"/>
         <source>Factors list cleared</source>
         <translation>Список факторов влияния очищен</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Missed input data</source>
         <translation>Не заданы входные данные</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="772"/>
+        <location filename="../moluscedialog.py" line="964"/>
         <source>Factors rasters is not set. Please specify them and try again</source>
         <translation>Карты влияния факторов не заданы. Пожалуйста, укажите карты влияния факторов и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="548"/>
+        <location filename="../moluscedialog.py" line="716"/>
         <source>Initial or final raster is not set. Please specify input data and try again</source>
         <translation>Не задан растр начальных или конечных состояний. Пожалуйста, укажите входные данные и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Different geometry</source>
         <translation>Несовпадающие пространственные характеристики</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="461"/>
+        <location filename="../moluscedialog.py" line="573"/>
         <source>Geometries of the initial raster and final raster are different!</source>
         <translation>Пространственные характеристики растров начальных и конечных состояний не совпадают!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometry is matched</source>
         <translation>Пространственные характеристики совпадают</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="469"/>
+        <location filename="../moluscedialog.py" line="581"/>
         <source>Geometries of the rasters are matched!</source>
         <translation>Пространственные характеристики растров совпадают!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="493"/>
+        <location filename="../moluscedialog.py" line="661"/>
         <source>Memory Error occurred (correlation checking). Perhaps the system is low on memory.</source>
         <translation>Произошла ошибка памяти (расчет корреляции). Возможно, в системе недостаточно памяти.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="542"/>
+        <location filename="../moluscedialog.py" line="710"/>
         <source>Class statistics and transition matrix are updated</source>
         <translation>Обновлены таблица статистики по классам и матрица переходов</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="557"/>
+        <location filename="../moluscedialog.py" line="725"/>
         <source>Save change map</source>
         <translation>Сохранить карту изменений</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</source>
         <translation>GeoTIFF (*.tif *.tiff *.TIF *.TIFF)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1152"/>
+        <location filename="../moluscedialog.py" line="1346"/>
         <source>No file selected</source>
         <translation>Файл не выбран</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="615"/>
+        <location filename="../moluscedialog.py" line="783"/>
         <source>Change Map is created</source>
         <translation>Создана карта изменений</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1184"/>
+        <location filename="../moluscedialog.py" line="1378"/>
         <source>Initial raster is not set. Please specify it and try again</source>
         <translation>Не задан растр начальных состояний. Пожалуйста, укажите растр начальных состояний и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="632"/>
+        <location filename="../moluscedialog.py" line="800"/>
         <source>Prefix of transition potential maps is not set. Please specify it and try again</source>
         <translation>Не задан префикс файлов для карт-потенциалов переходов . Пожалуйста, укажите префикс и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Missed model</source>
         <translation>Модель не установлена</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Missed transition matrix</source>
         <translation>Матрица переходов не рассчитана</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="790"/>
+        <location filename="../moluscedialog.py" line="984"/>
         <source>Please calculate transition matrix and try again</source>
         <translation>Пожалуйста, рассчитайте матрицу переходов и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="816"/>
+        <location filename="../moluscedialog.py" line="1010"/>
         <source>Simulation process is started</source>
         <translation>Запущен процесс симуляции</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="852"/>
+        <location filename="../moluscedialog.py" line="1046"/>
         <source>Output path for risk function map is not set. Skipping this step</source>
         <translation>Не задан путь сохранения для карты уверенности в прогнозе. Пропуск этого шага</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="902"/>
+        <location filename="../moluscedialog.py" line="1096"/>
         <source>Output path for simulated risk map is not set. Skipping this step</source>
         <translation>Не задан путь сохранения для карты-прогноза изменений. Пропуск этого шага</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Not implemented yet</source>
         <translation>Карты-потенциалов переходов не реализованы</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="926"/>
+        <location filename="../moluscedialog.py" line="1120"/>
         <source>Transition potentials not implemented yet for the model.</source>
         <translation>Карты-потенциалов переходов для данной модели еще не реализованы.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="943"/>
+        <location filename="../moluscedialog.py" line="1137"/>
         <source>Simulation process is finished</source>
         <translation>Завершен процесс симуляции</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file</source>
         <translation>Не удается прочитать файл</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="988"/>
+        <location filename="../moluscedialog.py" line="1182"/>
         <source>Validation process is started</source>
         <translation>Запущен процесс валидации</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1030"/>
+        <location filename="../moluscedialog.py" line="1224"/>
         <source>Validation process is finished</source>
         <translation>Завершен процесс валидации</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable</source>
         <translation>Расчет каппа-статистики неприменим</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1092"/>
+        <location filename="../moluscedialog.py" line="1286"/>
         <source>Kappa validation process is started</source>
         <translation>Запущен процесс расчета каппа-статистики</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1111"/>
+        <location filename="../moluscedialog.py" line="1305"/>
         <source>Kappa validation process is finished</source>
         <translation>Завершен процесс расчета каппа-статистики</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1144"/>
+        <location filename="../moluscedialog.py" line="1338"/>
         <source>Save validation map</source>
         <translation>Сохранить карту ошибок</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1202"/>
+        <location filename="../moluscedialog.py" line="1396"/>
         <source>Process of Validation Map creating is started</source>
         <translation>Запущен процесс расчета карты ошибок</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1486"/>
+        <location filename="../moluscedialog.py" line="1681"/>
         <source>Pearson&apos;s Correlation</source>
         <translation>Коэффициент корреляции Пирсона</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1496"/>
+        <location filename="../moluscedialog.py" line="1691"/>
         <source>Cramer&apos;s Coefficient</source>
         <translation>Коэффициент Крамера</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1511"/>
+        <location filename="../moluscedialog.py" line="1706"/>
         <source>Joint Information Uncertainty</source>
         <translation>Коэффициент JIU (Общая информационная неопределенность)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1282"/>
+        <location filename="../moluscedialog.py" line="1477"/>
         <source>raster units</source>
         <translation>единицы измерения растра</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1547"/>
+        <location filename="../moluscedialog.py" line="1742"/>
         <source>sq. km.</source>
         <translation>кв. км.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1549"/>
+        <location filename="../moluscedialog.py" line="1744"/>
         <source>ha</source>
         <translation>га</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1700"/>
+        <location filename="../moluscedialog.py" line="1895"/>
         <source>Artificial Neural Network (Multi-layer Perceptron)</source>
         <translation>Нейронные сети (многослойный перцептрон)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1705"/>
+        <location filename="../moluscedialog.py" line="1900"/>
         <source>Weights of Evidence</source>
         <translation>Значимость признака</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1710"/>
+        <location filename="../moluscedialog.py" line="1905"/>
         <source>Multi Criteria Evaluation</source>
         <translation>Многокритериальная оценка</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1695"/>
+        <location filename="../moluscedialog.py" line="1890"/>
         <source>Logistic Regression</source>
         <translation>Логистическая регрессия</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1298"/>
+        <location filename="../moluscedialog.py" line="1493"/>
         <source>All</source>
         <translation>Полная</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1299"/>
+        <location filename="../moluscedialog.py" line="1494"/>
         <source>Random</source>
         <translation>Случайная</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1300"/>
+        <location filename="../moluscedialog.py" line="1495"/>
         <source>Stratified</source>
         <translation>Стратифицированная</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1308"/>
+        <location filename="../moluscedialog.py" line="1503"/>
         <source>Multiple-resolution budget</source>
         <translation>Величины ошибок при различных пространственных масштабах</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1406"/>
+        <location filename="../moluscedialog.py" line="1601"/>
         <source>Correlation checking</source>
         <translation>Расчет корреляции</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1521"/>
+        <location filename="../moluscedialog.py" line="1716"/>
         <source>Not applicable</source>
         <translation>Неприменимо</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1553"/>
+        <location filename="../moluscedialog.py" line="1748"/>
         <source>sq. </source>
         <translation>кв. </translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1597"/>
+        <location filename="../moluscedialog.py" line="1792"/>
         <source>Class color</source>
         <translation>Цвет класса</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1741"/>
+        <location filename="../moluscedialog.py" line="1936"/>
         <source>Nothing to save, samples were not yet generated as the model was not trained. Train the model first.</source>
         <translation>Невозможно сохранить, примеры еще не сгенерированы, так как модель не была обучена. Сначала обучите модель.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Missed samples</source>
         <translation>Примеры не установлены</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1819"/>
+        <location filename="../moluscedialog.py" line="2014"/>
         <source>Save file</source>
         <translation>Сохранить файл</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1758"/>
+        <location filename="../moluscedialog.py" line="1953"/>
         <source>Shape files (*.shp *.SHP *.Shp)</source>
         <translation>Shape files (*.shp *.SHP *.Shp)</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file</source>
         <translation>Не удается сохранить файл</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Can&apos;t open file</source>
         <translation>Не удается открыть файл</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1813"/>
+        <location filename="../moluscedialog.py" line="2008"/>
         <source>Select Directory name</source>
         <translation>Укажите имя каталога</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1845"/>
+        <location filename="../moluscedialog.py" line="2040"/>
         <source>Open file</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1871"/>
+        <location filename="../moluscedialog.py" line="2066"/>
         <source>An unknown error occurs during validation procedure</source>
         <translation>Во время процедуры валидации произошла неизвестная ошибка</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1898"/>
+        <location filename="../moluscedialog.py" line="2093"/>
         <source>Can&apos;t load raster %s</source>
         <translation>Не удалось загрузить растр %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2066"/>
+        <location filename="../moluscedialog.py" line="2261"/>
         <source>Persistent</source>
         <translation>Постоянный</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>Raster must store codes of a nominal variable</source>
         <translation>Растр должен хранить коды номинальной переменной</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="307"/>
+        <location filename="../moluscedialog.py" line="315"/>
         <source>The raster has a lot of different values. Does the raster store a nominal variable?</source>
         <translation>Растр имеет множество различных значений. Хранит ли растр номинальную переменную?</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="452"/>
+        <location filename="../moluscedialog.py" line="618"/>
         <source>Geometries of the initial raster and raster &apos;{}&apos; are different!</source>
-        <translation>Пространственные характеристики растров начальных и конечных состояний '{}' не совпадают!</translation>
+        <translation>Пространственные характеристики растров начальных и конечных состояний &apos;{}&apos; не совпадают!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1135"/>
+        <location filename="../moluscedialog.py" line="1329"/>
         <source>Can&apos;t read file: &apos;{}&apos;</source>
-        <translation>Не удается прочитать файл: '{}'</translation>
+        <translation>Не удается прочитать файл: &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1786"/>
+        <location filename="../moluscedialog.py" line="1981"/>
         <source>Can&apos;t save file: &apos;{}&apos;</source>
-        <translation>Не удается сохранить файл: '{}'</translation>
+        <translation>Не удается сохранить файл: &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1801"/>
+        <location filename="../moluscedialog.py" line="1996"/>
         <source>Error loading output shapefile:
 {}</source>
         <translation>Ошибка при загрузке выходного файла:
 {}</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="386"/>
+        <location filename="../moluscedialog.py" line="487"/>
         <source>Factor raster is not selected. Please specify it and try again</source>
         <translation>Не выбрана карта влияния фактора. Пожалуйста, укажите карту влияния фактора и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="782"/>
+        <location filename="../moluscedialog.py" line="976"/>
         <source>Model not selected. Please select and train model.</source>
         <translation>Модель не выбрана. Пожалуйста, выберите и обучите модель.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1058"/>
+        <location filename="../moluscedialog.py" line="1252"/>
         <source>Kappa is not applicable to the file: &apos;{}&apos; because it contains continuous value</source>
-        <translation>Расчет каппа-статистики неприменим к файлу: '{}', поскольку он содержит непрерывное значение</translation>
+        <translation>Расчет каппа-статистики неприменим к файлу: &apos;{}&apos;, поскольку он содержит непрерывное значение</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1751"/>
+        <location filename="../moluscedialog.py" line="1946"/>
         <source>Selected model doesn&apos;t use samples</source>
         <translation>В выбранной модели не используются примеры</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1864"/>
+        <location filename="../moluscedialog.py" line="2059"/>
         <source>The system is out of memory during validation procedure</source>
         <translation>Во время процедуры валидации произошло переполнение выделенной памяти</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1539"/>
+        <location filename="../moluscedialog.py" line="1734"/>
         <source>metre</source>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1540"/>
+        <location filename="../moluscedialog.py" line="1735"/>
         <source>meter</source>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1541"/>
+        <location filename="../moluscedialog.py" line="1736"/>
         <source>meters</source>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1542"/>
+        <location filename="../moluscedialog.py" line="1737"/>
         <source>metres</source>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1543"/>
+        <location filename="../moluscedialog.py" line="1738"/>
         <source>unknown</source>
         <translation>unknown</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 perfect quantity inform.</source>
         <translation>Идеальный уровень информации о положении,
 идеальный уровень информации о количестве.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 no quantity inform.</source>
         <translation>Нет информации о положении,
 нет информации о количестве.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>No location,
 medium quantity inform.</source>
         <translation>Нет информации о положении,
 средний уровень информации о количестве.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Medium location,
 medium quantity inform.</source>
         <translation>Средний уровень информации о положении,
 Средний уровень информации о количестве.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1359"/>
+        <location filename="../moluscedialog.py" line="1554"/>
         <source>Perfect location,
 medium quantity inform.</source>
         <translation>Идеальный уровень информации о положении,
 средний уровень информации о количестве.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="243"/>
+        <location filename="../moluscedialog.py" line="251"/>
         <source>Set initial layer to %s</source>
         <translation>Установлен растр начальных состояний - %s</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1230"/>
+        <location filename="../moluscedialog.py" line="1424"/>
         <source>Process of Validation Map creating is finished</source>
         <translation>Завершен процесс расчета карты ошибок</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>File &apos;{}&apos; is used in the QGIS project. It is not possible to overwrite the file, specify a different file name and try again</source>
-        <translation>Файл '{}' используется в проекте QGIS. Невозможно перезаписать файл, укажите другое имя файла и повторите попытку</translation>
+        <translation>Файл &apos;{}&apos; используется в проекте QGIS. Невозможно перезаписать файл, укажите другое имя файла и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="642"/>
+        <location filename="../moluscedialog.py" line="810"/>
         <source>Directory of transition potential maps is not set. Please specify it and try again</source>
         <translation>Директория сохранения карт потенциальных переходов не задана. Пожалуйста, укажите ее и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Overwrite file</source>
         <translation>Перезапись файла</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="658"/>
+        <location filename="../moluscedialog.py" line="826"/>
         <source>Files with the specified prefix already exist in this directory. This may cause the files to be overwritten. Are you sure you want to continue?</source>
         <translation>Файлы с указанным префиксом уже существуют в данной директории. Это может привести к перезаписи файлов. Вы уверены, что хотите продолжить?</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="742"/>
+        <location filename="../moluscedialog.py" line="910"/>
         <source>Can&apos;t save file in the specified path &apos;{}&apos;. Please specify output path correctly and try again</source>
-        <translation>Не удается сохранить файл по указанному пути '{}'. Пожалуйста, укажите путь сохранения корректно и повторите попытку</translation>
+        <translation>Не удается сохранить файл по указанному пути &apos;{}&apos;. Пожалуйста, укажите путь сохранения корректно и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Different characteristics of rasters</source>
         <translation>Несовпадающие характеристики растров</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1173"/>
+        <location filename="../moluscedialog.py" line="1367"/>
         <source>Characteristics of the reference and simulated rasters are different!</source>
         <translation>Характеристики растров карты истинных значений и карты-результата симуляции не совпадают!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1075"/>
+        <location filename="../moluscedialog.py" line="1269"/>
         <source>Geometries of the reference and simulated rasters are different!</source>
         <translation>Пространственные характеристики растров карты истинных значений и карты-результата симуляции не совпадают!</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="2018"/>
+        <location filename="../moluscedialog.py" line="2213"/>
         <source>Init raster should be in PseudoColor or Paletted mode. Style not applied.</source>
         <translation>Растр начальных состояний должен быть в режиме отображения &quot;Одноканальное псевдоцветное&quot; или &quot;Палитра / Уникальные значения&quot;. Стиль не применен.</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="1770"/>
+        <location filename="../moluscedialog.py" line="1965"/>
         <source>Can&apos;t rewrite file</source>
         <translation>Не удается перезаписать файл</translation>
     </message>
     <message>
-        <location filename="../moluscedialog.py" line="761"/>
+        <location filename="../moluscedialog.py" line="929"/>
         <source>Can&apos;t save files with the same output path &apos;{}&apos;. Please specify different output paths and try again</source>
-        <translation>Не удается сохранить файлы по одинаковому пути сохранения '{}'. Пожалуйста, укажите разные пути сохранения и повторите попытку</translation>
+        <translation>Не удается сохранить файлы по одинаковому пути сохранения &apos;{}&apos;. Пожалуйста, укажите разные пути сохранения и повторите попытку</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="429"/>
+        <source>Added factor (sim) layer %s</source>
+        <translation>Добавлена карта влияния фактора для симуляции - %s</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="513"/>
+        <source>Removed factor (sim) layer %s</source>
+        <translation>Удалена карта влияния фактора для симуляции - %s</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="539"/>
+        <source>Factors list (sim) cleared</source>
+        <translation>Список факторов влияния для симуляции очищен</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Different number of variables</source>
+        <translation>Разное количество переменных</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="605"/>
+        <source>Model is trained using {} variables, and simulation was set up with {} variables</source>
+        <translation>Модель обучена с использованием {} переменных, а для симуляции настроено использование {} переменных</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Different number of bands</source>
+        <translation>Различное количество каналов</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="628"/>
+        <source>Training variable {} and simulation variable {} have different number of bands, {} and {} respectively</source>
+        <translation>Переменная {} на этапе обучения и переменная {} на этапе симуляции имеют разное число каналов, {} и {} соответственно</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Consistancy is checked</source>
+        <translation>Консистетность проверена</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="637"/>
+        <source>Training variables and Simulation variables are matched!</source>
+        <translation>Переменные для обучения и для симуляции консистентны!</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="941"/>
+        <source>Factors rasters for simulation are not set. Please specify them and try again, or disable their usage</source>
+        <translation>Карты влияния факторов для симуляции не заданы. Пожалуйста, укажите карты влияния факторов и повторите попытку</translation>
+    </message>
+    <message>
+        <location filename="../moluscedialog.py" line="951"/>
+        <source>Separate variables version consistency is not checked</source>
+        <translation>Отдельная версия пространственных переменных для симуляции не проверена на консистентность и переменными для обучения модели</translation>
     </message>
 </context>
 <context>
@@ -974,17 +1029,17 @@ medium quantity inform.</source>
         <translation>Растр конечных состояний &gt;&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="105"/>
+        <location filename="../ui/moluscedialogbase.ui" line="638"/>
         <source>&lt;&lt; Remove all</source>
         <translation>&lt;&lt; Удалить все</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="112"/>
+        <location filename="../ui/moluscedialogbase.ui" line="631"/>
         <source>&lt;&lt; Remove</source>
         <translation>&lt;&lt; Удалить</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="119"/>
+        <location filename="../ui/moluscedialogbase.ui" line="611"/>
         <source>Add &gt;&gt;</source>
         <translation>Добавить &gt;&gt;</translation>
     </message>
@@ -1094,22 +1149,22 @@ medium quantity inform.</source>
         <translation>Симуляция</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="725"/>
+        <location filename="../ui/moluscedialogbase.ui" line="797"/>
         <source>Browse...</source>
         <translation>Выбор файлов...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="574"/>
+        <location filename="../ui/moluscedialogbase.ui" line="540"/>
         <source>Certainty function</source>
         <translation>Карта уверенности в прогнозе</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="554"/>
+        <location filename="../ui/moluscedialogbase.ui" line="564"/>
         <source>Simulation result</source>
         <translation>Результат симуляции</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="540"/>
+        <location filename="../ui/moluscedialogbase.ui" line="550"/>
         <source>Number of simulation iterations</source>
         <translation>Число итераций симуляции</translation>
     </message>
@@ -1119,77 +1174,77 @@ medium quantity inform.</source>
         <translation>potential_</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="620"/>
+        <location filename="../ui/moluscedialogbase.ui" line="692"/>
         <source>Start</source>
         <translation>Пуск</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="643"/>
+        <location filename="../ui/moluscedialogbase.ui" line="715"/>
         <source>Validation</source>
         <translation>Валидация</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="683"/>
+        <location filename="../ui/moluscedialogbase.ui" line="755"/>
         <source>Create...</source>
         <translation>Создать...</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="690"/>
+        <location filename="../ui/moluscedialogbase.ui" line="762"/>
         <source>Validation Map</source>
         <translation>Карта ошибок</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="697"/>
+        <location filename="../ui/moluscedialogbase.ui" line="769"/>
         <source>Simulated Map</source>
         <translation>Карта-результат симуляции</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="711"/>
+        <location filename="../ui/moluscedialogbase.ui" line="783"/>
         <source>Reference Map</source>
         <translation>Карта истинных значений</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="752"/>
+        <location filename="../ui/moluscedialogbase.ui" line="824"/>
         <source>Number of validation iterations</source>
         <translation>Число итераций валидации</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="759"/>
+        <location filename="../ui/moluscedialogbase.ui" line="831"/>
         <source>Check persistent classes</source>
         <translation>Рассчитать постоянные классы</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="785"/>
+        <location filename="../ui/moluscedialogbase.ui" line="857"/>
         <source>% of Correctness</source>
         <translation>% правильных ответов</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="857"/>
+        <location filename="../ui/moluscedialogbase.ui" line="929"/>
         <source>Calculate kappa</source>
         <translation>Рассчитать каппа-статистики</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="864"/>
+        <location filename="../ui/moluscedialogbase.ui" line="936"/>
         <source>Start validation</source>
         <translation>Начать валидацию</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="874"/>
+        <location filename="../ui/moluscedialogbase.ui" line="946"/>
         <source>Messages</source>
         <translation>Сообщения</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="811"/>
+        <location filename="../ui/moluscedialogbase.ui" line="883"/>
         <source>Kappa (overall)</source>
         <translation>Каппа (общая)</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="837"/>
+        <location filename="../ui/moluscedialogbase.ui" line="909"/>
         <source>Kappa (histogram)</source>
         <translation>Каппа (гистограмма)</translation>
     </message>
     <message>
-        <location filename="../ui/moluscedialogbase.ui" line="850"/>
+        <location filename="../ui/moluscedialogbase.ui" line="922"/>
         <source>Kappa (location)</source>
         <translation>Каппа (положение)</translation>
     </message>
@@ -1212,6 +1267,16 @@ medium quantity inform.</source>
         <location filename="../ui/moluscedialogbase.ui" line="484"/>
         <source>Select Directory...</source>
         <translation>Выбрать директорию...</translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="596"/>
+        <source>Set separate spatial variables version for simulation</source>
+        <translation>Использовать отдельную версию пространственных переменных для симуляции</translation>
+    </message>
+    <message>
+        <location filename="../ui/moluscedialogbase.ui" line="645"/>
+        <source>Check consistency</source>
+        <translation>Проверить консистентность</translation>
     </message>
 </context>
 <context>
@@ -1642,13 +1707,13 @@ medium quantity inform.</source>
     </message>
     <message>
         <location filename="../algorithms/models/woe/manager.py" line="293"/>
-        <source><byte value="x9"/> factor: {} 
+        <source>	 factor: {} 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../algorithms/models/woe/manager.py" line="296"/>
-        <source><byte value="x9"/><byte value="x9"/> Weights of band {}: {} 
+        <source>		 Weights of band {}: {} 
 </source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/molusce/metadata.txt
+++ b/src/molusce/metadata.txt
@@ -9,7 +9,7 @@ about[ja] = プラグインは、ANN、LR、WoE、MCEなどの土地利用変化
 about[pt] = O Plugin fornece um conjunto de algoritmos para simulações de mudança de uso da terra, como ANN, LR, WoE, MCE. Há também validação utilizando estatísticas kappa. Desenvolvido por Asia Air Survey e NextGIS. Qualquer feedback é bem-vindo em https://nextgis.com/contact
 description = Modules for Land Use Change Simulations
 category = Raster
-version = 4.2.1
+version = 4.3.0
 qgisMinimumVersion = 3.22
 qgisMaximumVersion = 3.99
 
@@ -30,6 +30,8 @@ experimental = False
 deprecated = False
 
 changelog=
+        4.3.0
+            * Added support for separate version of spatial variables for sumilation
         4.2.1
             * Fixed the ability to copy data from a table
         4.2.0

--- a/src/molusce/moluscedialog.py
+++ b/src/molusce/moluscedialog.py
@@ -387,10 +387,10 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         self.__updateAnalyticTabs(self.geometry_matched)
         gc.collect()
 
-    def addFactorSeparateVars(self):
-        layerNames = self.lstLayersSeparateVars.selectedItems()
+    def addFactorSeparateVars(self) -> None:
+        layer_names = self.lstLayersSeparateVars.selectedItems()
 
-        if len(layerNames) <= 0:
+        if len(layer_names) == 0:
             QMessageBox.warning(
                 self,
                 self.tr("Missed selected row"),
@@ -400,39 +400,39 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             )
             return
 
-        for i in layerNames:
-            layerName = i.text()
+        for layer_name_record in layer_names:
+            layer_name = layer_name_record.text()
 
-            if len(self.lstFactorsSeparateVars.findItems(layerName, Qt.MatchExactly)) > 0:
+            if len(self.lstFactorsSeparateVars.findItems(layer_name, Qt.MatchFlag.MatchExactly)) > 0:
                 return
 
-            item = QListWidgetItem(i)
-            layerId = str(item.data(Qt.UserRole))
+            item = QListWidgetItem(layer_name_record)
+            layer_id = str(item.data(Qt.ItemDataRole.UserRole))
             self.lstFactorsSeparateVars.insertItem(self.lstFactors.count() + 1, item)
 
             try:
                 if "factors_sim" in self.inputs:
-                    self.inputs["factors_sim"][layerId] = Raster(
-                        str(utils.getLayerById(layerId).source()),
-                        utils.getLayerMaskById(layerId),
+                    self.inputs["factors_sim"][layer_id] = Raster(
+                        str(utils.getLayerById(layer_id).source()),
+                        utils.getLayerMaskById(layer_id),
                     )
                 else:
                     d = dict()
-                    d[layerId] = Raster(
-                        str(utils.getLayerById(layerId).source()),
-                        utils.getLayerMaskById(layerId),
+                    d[layer_id] = Raster(
+                        str(utils.getLayerById(layer_id).source()),
+                        utils.getLayerMaskById(layer_id),
                     )
                     self.inputs["factors_sim"] = d
 
                 self.inputs["bandCount_sim"] = self.__bandCount(sim=True)
 
-                self.logMessage(self.tr("Added factor (sim) layer %s") % (layerName))
+                self.logMessage(self.tr("Added factor (sim) layer %s") % (layer_name))
             except MemoryError:
                 self.logErrorReport(
                     self.tr(
                         "Memory Error occurred (loading raster %s). Perhaps the system is low on memory."
                     )
-                    % (layerName)
+                    % (layer_name)
                 )
                 QMessageBox.warning(
                     self,
@@ -441,10 +441,10 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
                         "Memory error occurred. Perhaps the system is low on memory."
                     ),
                 )
+                self.consistency_sim_checked = False
                 raise
                 return
         self.consistency_sim_checked = False
-        gc.collect()
 
     def removeFactor(self):
         layerNames = self.lstFactors.selectedItems()
@@ -480,10 +480,10 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             self.logMessage(self.tr("Removed factor layer %s") % (layerName))
             gc.collect()
 
-    def removeFactorSeparateVars(self):
-        layerNames = self.lstFactorsSeparateVars.selectedItems()
+    def removeFactorSeparateVars(self) -> None:
+        layer_names = self.lstFactorsSeparateVars.selectedItems()
 
-        if len(layerNames) <= 0:
+        if len(layer_names) == 0:
             QMessageBox.warning(
                 self,
                 self.tr("Missed selected row"),
@@ -493,13 +493,13 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             )
             return
 
-        for i in layerNames:
-            layerId = str(i.data(Qt.UserRole))
-            layerName = i.text()
+        for layer_name_record in layer_names:
+            layer_id = str(layer_name_record.data(Qt.ItemDataRole.UserRole))
+            layer_name = layer_name_record.text()
 
-            self.lstFactorsSeparateVars.takeItem(self.lstFactorsSeparateVars.row(i))
+            self.lstFactorsSeparateVars.takeItem(self.lstFactorsSeparateVars.row(layer_name_record))
 
-            del self.inputs["factors_sim"][layerId]
+            del self.inputs["factors_sim"][layer_id]
             gc.collect()
 
             if self.inputs["factors_sim"] == {}:
@@ -510,8 +510,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             else:
                 self.inputs["bandCount_sim"] = self.__bandCount(sim=True)
 
-            self.logMessage(self.tr("Removed factor (sim) layer %s") % (layerName))
-            gc.collect()
+            self.logMessage(self.tr("Removed factor (sim) layer %s") % (layer_name))
 
     def removeAllFactors(self):
         self.lstFactors.clear()
@@ -526,12 +525,11 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         self.__updateAnalyticTabs(self.geometry_matched)
         self.logMessage(self.tr("Factors list cleared"))
 
-    def removeAllFactorsSeparateVars(self):
+    def removeAllFactorsSeparateVars(self) -> None:
         self.lstFactorsSeparateVars.clear()
         try:
             del self.inputs["factors_sim"]
             del self.inputs["bandCount_sim"]
-            gc.collect()
         except KeyError:
             pass
 
@@ -586,7 +584,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         self.geometry_matched = True
         self.__updateAnalyticTabs(self.geometry_matched)
 
-    def checkConsistencySeparateVars(self):
+    def checkConsistencySeparateVars(self) -> None:
         # separate spatial variables for simulations should be:
         # - same number of variables as training ones
         # - same number of bands for each matching variable
@@ -611,10 +609,10 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
                 )
             return
 
-        initRaster = self.inputs["initial"]
-        for (_k, v), (_k2, v2) in zip(self.inputs["factors_sim"].items(), self.inputs["factors"].items()):
+        init_raster = self.inputs["initial"]
+        for (_k, v), (_k2, v2) in zip(self.inputs["factors_sim"].values(), self.inputs["factors"].values()):
 
-            if not initRaster.geoDataMatch(v):
+            if not init_raster.geoDataMatch(v):
                 QMessageBox.warning(
                     self,
                     self.tr("Different geometry"),
@@ -624,7 +622,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
                 )
                 return
 
-            if not (v.bandcount == v2.bandcount):
+            if v.bandcount != v2.bandcount:
                 QMessageBox.warning(
                     self,
                     self.tr("Different number of bands"),
@@ -2094,11 +2092,11 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
 
     def __bandCount(self, sim=False):
         bands = 0
-        if sim == False:
-            for _k, v in self.inputs["factors"].items():
+        if not sim:
+            for _k, v in self.inputs["factors"].values():
                 bands += v.getBandsCount()
         else:
-            for _k, v in self.inputs["factors_sim"].items():
+            for _k, v in self.inputs["factors_sim"].values():
                 bands += v.getBandsCount()
         return bands
 

--- a/src/molusce/moluscedialog.py
+++ b/src/molusce/moluscedialog.py
@@ -126,18 +126,26 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         # connect signals and slots
         self.btnSetInitialRaster.clicked.connect(self.setInitialRaster)
         self.btnSetFinalRaster.clicked.connect(self.setFinalRaster)
-        
+
         self.btnAddFactor.clicked.connect(self.addFactor)
-        self.btnAddFactorSeparateVars.clicked.connect(self.addFactorSeparateVars)
-        
+        self.btnAddFactorSeparateVars.clicked.connect(
+            self.addFactorSeparateVars
+        )
+
         self.btnRemoveFactor.clicked.connect(self.removeFactor)
-        self.btnRemoveFactorSeparateVars.clicked.connect(self.removeFactorSeparateVars)
-        
+        self.btnRemoveFactorSeparateVars.clicked.connect(
+            self.removeFactorSeparateVars
+        )
+
         self.btnRemoveAllFactors.clicked.connect(self.removeAllFactors)
-        self.btnRemoveAllFactorsSeparateVars.clicked.connect(self.removeAllFactorsSeparateVars)
+        self.btnRemoveAllFactorsSeparateVars.clicked.connect(
+            self.removeAllFactorsSeparateVars
+        )
 
         self.btnCheckGeometry.clicked.connect(self.checkGeometry)
-        self.btnCheckConsistencySeparateVars.clicked.connect(self.checkConsistencySeparateVars)
+        self.btnCheckConsistencySeparateVars.clicked.connect(
+            self.checkConsistencySeparateVars
+        )
 
         self.chkAllCorr.stateChanged.connect(self.__toggleCorrLayers)
         self.btnStartCorrChecking.clicked.connect(self.correlationChecking)
@@ -403,12 +411,21 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         for layer_name_record in layer_names:
             layer_name = layer_name_record.text()
 
-            if len(self.lstFactorsSeparateVars.findItems(layer_name, Qt.MatchFlag.MatchExactly)) > 0:
+            if (
+                len(
+                    self.lstFactorsSeparateVars.findItems(
+                        layer_name, Qt.MatchFlag.MatchExactly
+                    )
+                )
+                > 0
+            ):
                 return
 
             item = QListWidgetItem(layer_name_record)
             layer_id = str(item.data(Qt.ItemDataRole.UserRole))
-            self.lstFactorsSeparateVars.insertItem(self.lstFactors.count() + 1, item)
+            self.lstFactorsSeparateVars.insertItem(
+                self.lstFactors.count() + 1, item
+            )
 
             try:
                 if "factors_sim" in self.inputs:
@@ -417,16 +434,18 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
                         utils.getLayerMaskById(layer_id),
                     )
                 else:
-                    d = dict()
-                    d[layer_id] = Raster(
+                    factors_sim = dict()
+                    factors_sim[layer_id] = Raster(
                         str(utils.getLayerById(layer_id).source()),
                         utils.getLayerMaskById(layer_id),
                     )
-                    self.inputs["factors_sim"] = d
+                    self.inputs["factors_sim"] = factors_sim
 
                 self.inputs["bandCount_sim"] = self.__bandCount(sim=True)
 
-                self.logMessage(self.tr("Added factor (sim) layer %s") % (layer_name))
+                self.logMessage(
+                    self.tr("Added factor (sim) layer %s") % (layer_name)
+                )
             except MemoryError:
                 self.logErrorReport(
                     self.tr(
@@ -442,8 +461,8 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
                     ),
                 )
                 self.consistency_sim_checked = False
-                raise
                 return
+
         self.consistency_sim_checked = False
 
     def removeFactor(self):
@@ -497,7 +516,9 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             layer_id = str(layer_name_record.data(Qt.ItemDataRole.UserRole))
             layer_name = layer_name_record.text()
 
-            self.lstFactorsSeparateVars.takeItem(self.lstFactorsSeparateVars.row(layer_name_record))
+            self.lstFactorsSeparateVars.takeItem(
+                self.lstFactorsSeparateVars.row(layer_name_record)
+            )
 
             del self.inputs["factors_sim"][layer_id]
             gc.collect()
@@ -510,7 +531,9 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             else:
                 self.inputs["bandCount_sim"] = self.__bandCount(sim=True)
 
-            self.logMessage(self.tr("Removed factor (sim) layer %s") % (layer_name))
+            self.logMessage(
+                self.tr("Removed factor (sim) layer %s") % (layer_name)
+            )
 
     def removeAllFactors(self):
         self.lstFactors.clear()
@@ -599,19 +622,24 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             )
             return
 
-        if not (len(self.inputs['factors']) == len(self.inputs['factors_sim'])):
+        if len(self.inputs["factors"]) != len(self.inputs["factors_sim"]):
             QMessageBox.warning(
-                    self,
-                    self.tr("Different number of variables"),
-                    self.tr(
-                        "Model is trained using {} variables, and simulation was set up with {} variables"
-                    ).format(len(self.inputs['factors']),len(self.inputs['factors_sim'])),
-                )
+                self,
+                self.tr("Different number of variables"),
+                self.tr(
+                    "Model is trained using {} variables, and simulation was set up with {} variables"
+                ).format(
+                    len(self.inputs["factors"]),
+                    len(self.inputs["factors_sim"]),
+                ),
+            )
             return
 
         init_raster = self.inputs["initial"]
-        for v, v2 in zip(self.inputs["factors_sim"].values(), self.inputs["factors"].values()):
-
+        for v, v2 in zip(
+            self.inputs["factors_sim"].values(),
+            self.inputs["factors"].values(),
+        ):
             if not init_raster.geoDataMatch(v):
                 QMessageBox.warning(
                     self,
@@ -628,19 +656,26 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
                     self.tr("Different number of bands"),
                     self.tr(
                         "Training variable {} and simulation variable {} have different number of bands, {} and {} respectively"
-                    ).format(v.getFileName(), v2.getFileName(), v.bandcount, v2.bandcount),
+                    ).format(
+                        v.getFileName(),
+                        v2.getFileName(),
+                        v.bandcount,
+                        v2.bandcount,
+                    ),
                 )
                 return
 
         QMessageBox.warning(
             self,
             self.tr("Consistancy is checked"),
-            self.tr("Training variables and Simulation variables are matched!"),
+            self.tr(
+                "Training variables and Simulation variables are matched!"
+            ),
         )
 
         self.consistency_sim_checked = True
 
-    def correlationChecking(self):
+    def correlationChecking(self) -> None:
         if not utils.checkFactors(self.inputs):
             QMessageBox.warning(
                 self,
@@ -933,7 +968,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
                     ).format(self.leMonteCarloPath.text()),
                 )
                 return
-            
+
         if self.chkSeparateVars.isChecked():
             if not utils.checkFactors(self.inputs, sim=True):
                 QMessageBox.warning(
@@ -1660,7 +1695,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         for i in range(dimensions[0]):
             raster = first["Raster"]
             if raster.getBandsCount() > 1:
-                name = f"{first['Name']} (band {str(i+1)}"
+                name = f"{first['Name']} (band {str(i + 1)}"
             else:
                 name = str(first["Name"])
             labels.append(name)
@@ -1669,7 +1704,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         for i in range(dimensions[1]):
             raster = second["Raster"]
             if raster.getBandsCount() > 1:
-                name = f"{second['Name']} (band {str(i+1)})"
+                name = f"{second['Name']} (band {str(i + 1)})"
             else:
                 name = str(second["Name"])
             labels.append(name)
@@ -2090,14 +2125,11 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         else:
             self.logMessage(self.tr("Can't load raster %s") % (filePath))
 
-    def __bandCount(self, sim=False):
+    def __bandCount(self, sim: bool = False) -> int:
         bands = 0
-        if not sim:
-            for v in self.inputs["factors"].values():
-                bands += v.getBandsCount()
-        else:
-            for v in self.inputs["factors_sim"].values():
-                bands += v.getBandsCount()
+        factors_key = "factors_sim" if sim else "factors"
+        for v in self.inputs.get(factors_key, {}).values():
+            bands += v.getBandsCount()
         return bands
 
     def setProgressRange(self, message, maxValue):

--- a/src/molusce/moluscedialog.py
+++ b/src/molusce/moluscedialog.py
@@ -610,7 +610,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             return
 
         init_raster = self.inputs["initial"]
-        for (_k, v), (_k2, v2) in zip(self.inputs["factors_sim"].values(), self.inputs["factors"].values()):
+        for v, v2 in zip(self.inputs["factors_sim"].values(), self.inputs["factors"].values()):
 
             if not init_raster.geoDataMatch(v):
                 QMessageBox.warning(
@@ -2093,10 +2093,10 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
     def __bandCount(self, sim=False):
         bands = 0
         if not sim:
-            for _k, v in self.inputs["factors"].values():
+            for v in self.inputs["factors"].values():
                 bands += v.getBandsCount()
         else:
-            for _k, v in self.inputs["factors_sim"].values():
+            for v in self.inputs["factors_sim"].values():
                 bands += v.getBandsCount()
         return bands
 

--- a/src/molusce/moluscedialog.py
+++ b/src/molusce/moluscedialog.py
@@ -424,7 +424,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
                     )
                     self.inputs["factors_sim"] = d
 
-                self.inputs["bandCount_sim"] = self.__bandCount()
+                self.inputs["bandCount_sim"] = self.__bandCount(sim=True)
 
                 self.logMessage(self.tr("Added factor (sim) layer %s") % (layerName))
             except MemoryError:
@@ -508,7 +508,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
 
                 self.consistency_sim_checked = False
             else:
-                self.inputs["bandCount_sim"] = self.__bandCount()
+                self.inputs["bandCount_sim"] = self.__bandCount(sim=True)
 
             self.logMessage(self.tr("Removed factor (sim) layer %s") % (layerName))
             gc.collect()
@@ -2092,10 +2092,14 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         else:
             self.logMessage(self.tr("Can't load raster %s") % (filePath))
 
-    def __bandCount(self):
+    def __bandCount(self, sim=False):
         bands = 0
-        for _k, v in self.inputs["factors"].items():
-            bands += v.getBandsCount()
+        if sim == False:
+            for _k, v in self.inputs["factors"].items():
+                bands += v.getBandsCount()
+        else:
+            for _k, v in self.inputs["factors_sim"].items():
+                bands += v.getBandsCount()
         return bands
 
     def setProgressRange(self, message, maxValue):

--- a/src/molusce/molusceutils.py
+++ b/src/molusce/molusceutils.py
@@ -196,8 +196,11 @@ def checkInputRasters(userData):
     return bool("initial" in userData and "final" in userData)
 
 
-def checkFactors(userData):
-    return "factors" in userData
+def checkFactors(userData, sim=False):
+    if not sim:
+        return "factors" in userData
+    else:
+        return "factors_sim" in userData
 
 
 def checkChangeMap(userData):

--- a/src/molusce/ui/moluscedialogbase.ui
+++ b/src/molusce/ui/moluscedialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>887</width>
-    <height>519</height>
+    <height>792</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
       <bool>true</bool>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="tabInputs">
       <attribute name="title">
@@ -492,23 +492,6 @@
        </item>
        <item>
         <layout class="QGridLayout" name="gridLayout_4">
-         <item row="1" column="2">
-          <widget class="QPushButton" name="btnSelectRiskFunction">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="text">
-            <string>Browse...</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLineEdit" name="leRiskFunctionPath">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
          <item row="4" column="2">
           <widget class="QSpinBox" name="spnIterations">
            <property name="enabled">
@@ -528,6 +511,33 @@
            </property>
            <property name="value">
             <number>1</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QPushButton" name="btnSelectRiskFunction">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Browse...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QPushButton" name="btnSelectMonteCarlo">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Browse...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="chkRiskFunction">
+           <property name="text">
+            <string>Certainty function</string>
            </property>
           </widget>
          </item>
@@ -558,24 +568,86 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="2">
-          <widget class="QPushButton" name="btnSelectMonteCarlo">
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="leRiskFunctionPath">
            <property name="enabled">
             <bool>false</bool>
-           </property>
-           <property name="text">
-            <string>Browse...</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="chkRiskFunction">
-           <property name="text">
-            <string>Certainty function</string>
            </property>
           </widget>
          </item>
         </layout>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="chkSeparateVars">
+         <property name="title">
+          <string>Set separate spatial variables version for simulation</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="0" column="0" rowspan="4">
+           <widget class="QListWidget" name="lstLayersSeparateVars"/>
+          </item>
+          <item row="0" column="1">
+           <widget class="QPushButton" name="btnAddFactorSeparateVars">
+            <property name="text">
+             <string>Add &gt;&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2" rowspan="3">
+           <widget class="QListWidget" name="lstFactorsSeparateVars">
+            <property name="editTriggers">
+             <set>QAbstractItemView::NoEditTriggers</set>
+            </property>
+            <property name="alternatingRowColors">
+             <bool>true</bool>
+            </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPushButton" name="btnRemoveFactorSeparateVars">
+            <property name="text">
+             <string>&lt;&lt; Remove</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="btnRemoveAllFactorsSeparateVars">
+            <property name="text">
+             <string>&lt;&lt; Remove all</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
+           <widget class="QPushButton" name="btnCheckConsistencySeparateVars">
+            <property name="text">
+             <string>Check consistency</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </item>
        <item>
         <spacer name="verticalSpacer_2">
@@ -584,8 +656,8 @@
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>842</width>
-           <height>221</height>
+           <width>20</width>
+           <height>40</height>
           </size>
          </property>
         </spacer>


### PR DESCRIPTION
In this version users could set separate version of spatial variables for simulation.
![image](https://github.com/user-attachments/assets/312847ee-63c0-4b5c-a048-01661496dab7)

It could be very helpfull for predictions, where environmental factors are changing over time. For example, it makes possible to use climate change variables, taking into account different state during training period of time and simulation period.

Need help with:
- All translations except russian
- Code review