### PR TITLE
Model save/load mechanism implementation

### DIFF
--- a/src/molusce/algorithms/dataprovider.py
+++ b/src/molusce/algorithms/dataprovider.py
@@ -418,12 +418,14 @@ class Raster:
 
         self.geodata = geodata
 
-    def getUniqueValues(self)->set:
+    def getUniqueValues(self) -> set:
         # Get all unique pixel values contained in Raster
         unique_values = set()
         for band in range(self.getBandsCount()):
             band_data = self.getBand(band + 1)  # Get band (1-based index)
-            unique_band_values = np.unique(band_data.compressed())  # Get unique values, ignoring masked data
+            unique_band_values = np.unique(
+                band_data.compressed()
+            )  # Get unique values, ignoring masked data
             unique_values.update(unique_band_values)
 
         return unique_values

--- a/src/molusce/algorithms/dataprovider.py
+++ b/src/molusce/algorithms/dataprovider.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Set
 
 import numpy as np
 from numpy import ma as ma
@@ -165,13 +166,14 @@ class Raster:
             abs(s_height), abs(r_height)
         )
 
-    def getBand(self, bandNo):
+    def getBand(self, bandNo: int):
+        assert self.bands is not None
         return self.bands[bandNo - 1]
 
     def getBandsCount(self) -> int:
         return self.bandcount
 
-    def getBandGradation(self, bandNo):
+    def getBandGradation(self, bandNo: int):
         """Return list of categories of raster's band"""
         if bandNo < len(self.bandgradation):
             res = self.bandgradation[bandNo]
@@ -181,7 +183,7 @@ class Raster:
             self.bandgradation[bandNo] = res
         return res
 
-    def getBandStat(self, bandNo):
+    def getBandStat(self, bandNo: int):
         """Return mean and std of the raster's band"""
         band = self.getBand(bandNo)
         result = {}
@@ -255,10 +257,12 @@ class Raster:
     def getProjUnits(self):
         return self.geodata["units"]
 
-    def getXSize(self):
+    def getXSize(self) -> int:
+        assert self.geodata is not None and "xSize" in self.geodata
         return self.geodata["xSize"]
 
-    def getYSize(self):
+    def getYSize(self) -> int:
+        assert self.geodata is not None and "ySize" in self.geodata
         return self.geodata["ySize"]
 
     def isCountinues(self, bandNo):
@@ -418,7 +422,7 @@ class Raster:
 
         self.geodata = geodata
 
-    def getUniqueValues(self) -> set:
+    def getUniqueValues(self) -> Set:
         # Get all unique pixel values contained in Raster
         unique_values = set()
         for band in range(self.getBandsCount()):

--- a/src/molusce/algorithms/dataprovider.py
+++ b/src/molusce/algorithms/dataprovider.py
@@ -417,3 +417,13 @@ class Raster:
                 )
 
         self.geodata = geodata
+
+    def getUniqueValues(self)->set:
+        # Get all unique pixel values contained in Raster
+        unique_values = set()
+        for band in range(self.getBandsCount()):
+            band_data = self.getBand(band + 1)  # Get band (1-based index)
+            unique_band_values = np.unique(band_data.compressed())  # Get unique values, ignoring masked data
+            unique_values.update(unique_band_values)
+
+        return unique_values

--- a/src/molusce/algorithms/models/area_analysis/manager.py
+++ b/src/molusce/algorithms/models/area_analysis/manager.py
@@ -188,7 +188,7 @@ class AreaAnalyst(QObject):
         self.initRaster = initR
 
     # Make AreaAnalyst class available for pickle
-    def __getstate__(self)->dict:
+    def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         return state
 

--- a/src/molusce/algorithms/models/area_analysis/manager.py
+++ b/src/molusce/algorithms/models/area_analysis/manager.py
@@ -186,3 +186,11 @@ class AreaAnalyst(QObject):
             raise AreaAnalizerError(self.tr("The raster must have 1 band!"))
 
         self.initRaster = initR
+
+    # Make AreaAnalyst class available for pickle
+    def __getstate__(self)->dict:
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state: dict):
+        self.__dict__.update(state)

--- a/src/molusce/algorithms/models/area_analysis/manager.py
+++ b/src/molusce/algorithms/models/area_analysis/manager.py
@@ -6,6 +6,7 @@ from qgis.PyQt.QtCore import *
 
 from molusce.algorithms.dataprovider import Raster
 from molusce.algorithms.utils import masks_identity
+from molusce.molusceutils import PickleQObjectMixin
 
 
 class AreaAnalizerError(Exception):
@@ -15,7 +16,7 @@ class AreaAnalizerError(Exception):
         self.msg = msg
 
 
-class AreaAnalyst(QObject):
+class AreaAnalyst(PickleQObjectMixin, QObject):
     """Generates an output raster, with geometry
     copied from the initial land use map.  The output is a 1-band raster
     with categories corresponding the (r,c) elements of the m-matrix of
@@ -186,11 +187,3 @@ class AreaAnalyst(QObject):
             raise AreaAnalizerError(self.tr("The raster must have 1 band!"))
 
         self.initRaster = initR
-
-    # Make AreaAnalyst class available for pickle
-    def __getstate__(self) -> dict:
-        state = self.__dict__.copy()
-        return state
-
-    def __setstate__(self, state: dict):
-        self.__dict__.update(state)

--- a/src/molusce/algorithms/models/lr/lr.py
+++ b/src/molusce/algorithms/models/lr/lr.py
@@ -12,6 +12,7 @@ from molusce.algorithms.models.correlation.model import (
     DependenceCoef,
 )
 from molusce.algorithms.models.sampler.sampler import Sampler
+from molusce.molusceutils import PickleQObjectMixin
 
 from . import multinomial_logistic_regression as mlr
 
@@ -23,7 +24,7 @@ class LRError(Exception):
         self.msg = msg
 
 
-class LR(QObject):
+class LR(PickleQObjectMixin, QObject):
     """Implements Logistic Regression model definition and calibration
     (maximum liklihood parameter estimation).
     """
@@ -334,12 +335,3 @@ class LR(QObject):
             raise
         finally:
             self.finished.emit()
-
-    # Make LR class available for pickle
-    def __getstate__(self) -> dict:
-        state = self.__dict__.copy()
-        return state
-
-    def __setstate__(self, state: dict) -> None:
-        self.__dict__.update(state)
-        QObject.__init__(self)

--- a/src/molusce/algorithms/models/lr/lr.py
+++ b/src/molusce/algorithms/models/lr/lr.py
@@ -336,10 +336,10 @@ class LR(QObject):
             self.finished.emit()
 
     # Make LR class available for pickle
-    def __getstate__(self)->dict:
+    def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         return state
 
-    def __setstate__(self, state: dict)->None:
+    def __setstate__(self, state: dict) -> None:
         self.__dict__.update(state)
         QObject.__init__(self)

--- a/src/molusce/algorithms/models/lr/lr.py
+++ b/src/molusce/algorithms/models/lr/lr.py
@@ -42,7 +42,7 @@ class LR(QObject):
     maxiter: int
 
     def __init__(self, ns=0, logreg: Optional[mlr.MLR] = None) -> None:
-        QObject.__init__(self)
+        super().__init__()
 
         if logreg:
             self.logreg = logreg
@@ -334,3 +334,12 @@ class LR(QObject):
             raise
         finally:
             self.finished.emit()
+
+    # Make LR class available for pickle
+    def __getstate__(self)->dict:
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state: dict)->None:
+        self.__dict__.update(state)
+        QObject.__init__(self)

--- a/src/molusce/algorithms/models/mce/mce.py
+++ b/src/molusce/algorithms/models/mce/mce.py
@@ -6,6 +6,7 @@ from qgis.PyQt.QtCore import *
 
 from molusce.algorithms.dataprovider import Raster
 from molusce.algorithms.utils import binaryzation
+from molusce.molusceutils import PickleQObjectMixin
 
 
 class MCEError(Exception):
@@ -15,7 +16,7 @@ class MCEError(Exception):
         self.msg = msg
 
 
-class MCE(QObject):
+class MCE(PickleQObjectMixin, QObject):
     logMessage = pyqtSignal(str)
     errorReport = pyqtSignal(str)
 
@@ -235,12 +236,3 @@ class MCE(QObject):
                 self.consistency = -1
         else:
             self.consistency = 0
-
-    # Make MCE class available for pickle
-    def __getstate__(self) -> dict:
-        state = self.__dict__.copy()
-        return state
-
-    def __setstate__(self, state: dict):
-        self.__dict__.update(state)
-        QObject.__init__(self)

--- a/src/molusce/algorithms/models/mce/mce.py
+++ b/src/molusce/algorithms/models/mce/mce.py
@@ -237,7 +237,7 @@ class MCE(QObject):
             self.consistency = 0
 
     # Make MCE class available for pickle
-    def __getstate__(self)->dict:
+    def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         return state
 

--- a/src/molusce/algorithms/models/mce/mce.py
+++ b/src/molusce/algorithms/models/mce/mce.py
@@ -69,7 +69,7 @@ class MCE(QObject):
         @param initStateNum     Number of initial state (the state before transition).
         @param finalStateNum    Number of final state (the state after transition).
         """
-        QObject.__init__(self)
+        super().__init__()
 
         self.factors = factors
         self.initStateNum = initStateNum
@@ -235,3 +235,12 @@ class MCE(QObject):
                 self.consistency = -1
         else:
             self.consistency = 0
+
+    # Make MCE class available for pickle
+    def __getstate__(self)->dict:
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state: dict):
+        self.__dict__.update(state)
+        QObject.__init__(self)

--- a/src/molusce/algorithms/models/mlp/manager.py
+++ b/src/molusce/algorithms/models/mlp/manager.py
@@ -13,6 +13,7 @@ from molusce.algorithms.models.correlation.model import (
 )
 from molusce.algorithms.models.mlp.model import MLP, sigmoid
 from molusce.algorithms.models.sampler.sampler import Sampler
+from molusce.molusceutils import PickleQObjectMixin
 
 
 class MlpManagerError(Exception):
@@ -22,7 +23,7 @@ class MlpManagerError(Exception):
         self.msg = msg
 
 
-class MlpManager(QObject):
+class MlpManager(PickleQObjectMixin, QObject):
     """This class gets the data extracted from the UI and
     pass it to multi-layer perceptron, then gets and stores the result.
     """
@@ -573,12 +574,3 @@ class MlpManager(QObject):
             input_data = np.hstack((sample["state"], sample["factors"]))
             self.getOutput(input_data)  # Forward propagation
             self.MLP.propagate_backward(sample["output"], lrate, momentum)
-
-    # Make MLPManager class available for pickle
-    def __getstate__(self) -> dict:
-        state = self.__dict__.copy()
-        return state
-
-    def __setstate__(self, state: dict) -> None:
-        self.__dict__.update(state)
-        QObject.__init__(self)

--- a/src/molusce/algorithms/models/mlp/manager.py
+++ b/src/molusce/algorithms/models/mlp/manager.py
@@ -42,7 +42,7 @@ class MlpManager(QObject):
     updateProgress = pyqtSignal()
 
     def __init__(self, ns=0, MLP=None):
-        QObject.__init__(self)
+        super().__init__()
 
         self.MLP = MLP
         self.interrupted = False
@@ -573,3 +573,12 @@ class MlpManager(QObject):
             input_data = np.hstack((sample["state"], sample["factors"]))
             self.getOutput(input_data)  # Forward propagation
             self.MLP.propagate_backward(sample["output"], lrate, momentum)
+
+    # Make MLPManager class available for pickle
+    def __getstate__(self)->dict:
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state:dict)->None:
+        self.__dict__.update(state)
+        QObject.__init__(self)

--- a/src/molusce/algorithms/models/mlp/manager.py
+++ b/src/molusce/algorithms/models/mlp/manager.py
@@ -575,10 +575,10 @@ class MlpManager(QObject):
             self.MLP.propagate_backward(sample["output"], lrate, momentum)
 
     # Make MLPManager class available for pickle
-    def __getstate__(self)->dict:
+    def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         return state
 
-    def __setstate__(self, state:dict)->None:
+    def __setstate__(self, state: dict) -> None:
         self.__dict__.update(state)
         QObject.__init__(self)

--- a/src/molusce/algorithms/models/mlp/model.py
+++ b/src/molusce/algorithms/models/mlp/model.py
@@ -100,6 +100,12 @@ class MLP:
         # Return error
         return (error**2).sum()
 
+    def __getstate__(self)->dict:
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state)->None:
+        self.__dict__.update(state)
 
 # -----------------------------------------------------------------------------
 

--- a/src/molusce/algorithms/models/mlp/model.py
+++ b/src/molusce/algorithms/models/mlp/model.py
@@ -100,13 +100,6 @@ class MLP:
         # Return error
         return (error**2).sum()
 
-    def __getstate__(self) -> dict:
-        state = self.__dict__.copy()
-        return state
-
-    def __setstate__(self, state) -> None:
-        self.__dict__.update(state)
-
 
 # -----------------------------------------------------------------------------
 

--- a/src/molusce/algorithms/models/mlp/model.py
+++ b/src/molusce/algorithms/models/mlp/model.py
@@ -100,12 +100,13 @@ class MLP:
         # Return error
         return (error**2).sum()
 
-    def __getstate__(self)->dict:
+    def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         return state
 
-    def __setstate__(self, state)->None:
+    def __setstate__(self, state) -> None:
         self.__dict__.update(state)
+
 
 # -----------------------------------------------------------------------------
 

--- a/src/molusce/algorithms/models/sampler/sampler.py
+++ b/src/molusce/algorithms/models/sampler/sampler.py
@@ -7,6 +7,7 @@ from osgeo import ogr, osr
 from qgis.PyQt.QtCore import *
 
 from molusce.algorithms.dataprovider import ProviderError
+from molusce.molusceutils import PickleQObjectMixin
 
 
 class SamplerError(Exception):
@@ -16,7 +17,7 @@ class SamplerError(Exception):
         self.msg = msg
 
 
-class Sampler(QObject):
+class Sampler(PickleQObjectMixin, QObject):
     """Create training set based on input-output rasters.
 
     A sample is a set of input data for a model and output data that has to be predicted via the model.
@@ -145,7 +146,7 @@ class Sampler(QObject):
             return None
         return np.hstack((state_data, factors_data))
 
-    def get_factors(self, row, col):
+    def get_factors(self, row: str, col: str) -> Optional[np.ma.MaskedArray]:
         """Get input sample at (row, col) pixel and return it as array. Return None if the sample is incomplete."""
         neighbours = self.factors[
             :,
@@ -452,11 +453,3 @@ class Sampler(QObject):
             raise
         finally:
             self.samplingFinished.emit()
-
-    # Make Sampler class available for pickle
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)

--- a/src/molusce/algorithms/models/sampler/sampler.py
+++ b/src/molusce/algorithms/models/sampler/sampler.py
@@ -452,3 +452,11 @@ class Sampler(QObject):
             raise
         finally:
             self.samplingFinished.emit()
+
+    # Make Sampler class available for pickle
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)

--- a/src/molusce/algorithms/models/serializer/__init__.py
+++ b/src/molusce/algorithms/models/serializer/__init__.py
@@ -1,0 +1,1 @@
+from .serializer import ModelParams, ModelParamsSerializer

--- a/src/molusce/algorithms/models/serializer/serializer.py
+++ b/src/molusce/algorithms/models/serializer/serializer.py
@@ -1,19 +1,21 @@
 import pickle
 from datetime import datetime
 
+from qgis.utils import pluginMetadata
+
 from molusce.algorithms.dataprovider import Raster
 from molusce.algorithms.models.lr.lr import LR
 from molusce.algorithms.models.mce.mce import MCE
 from molusce.algorithms.models.mlp.manager import MlpManager
 from molusce.algorithms.models.woe.manager import WoeManager
-from qgis.utils import pluginMetadata
 
 
 class SerializerError(Exception):
     def __init__(self, msg):
         self.msg = msg
 
-class Serializer():
+
+class Serializer:
     model = None
     base_xsize = None
     base_ysize = None
@@ -23,7 +25,17 @@ class Serializer():
     creation_ts = None
     molusce_version = None
 
-    def __init__(self, model, base_xsize, base_ysize, base_classes, factors_metadata, model_type, creation_ts, molusce_version):
+    def __init__(
+        self,
+        model,
+        base_xsize,
+        base_ysize,
+        base_classes,
+        factors_metadata,
+        model_type,
+        creation_ts,
+        molusce_version,
+    ):
         self.model = model
         self.base_xsize = base_xsize
         self.base_ysize = base_ysize
@@ -41,7 +53,7 @@ class Serializer():
         except Exception as e:
             raise SerializerError("Invalid file. %s" % str(e)) from e
 
-        if not all( 
+        if not all(
             k in imported_model
             for k in (
                 "model",
@@ -64,19 +76,19 @@ class Serializer():
         ):
             raise SerializerError("Invalid model type")
 
-        return cls(imported_model["model"],
-                imported_model["base_xsize"],
-                imported_model["base_ysize"],
-                imported_model["base_classes"],
-                imported_model["factors_metadata"],
-                imported_model["model_type"],
-                imported_model["creation_ts"],
-                imported_model["molusce_version"])
-
+        return cls(
+            imported_model["model"],
+            imported_model["base_xsize"],
+            imported_model["base_ysize"],
+            imported_model["base_classes"],
+            imported_model["factors_metadata"],
+            imported_model["model_type"],
+            imported_model["creation_ts"],
+            imported_model["molusce_version"],
+        )
 
     @classmethod
     def from_data(cls, inputs_model, inputs_initial, inputs_factors):
-
         if isinstance(inputs_model, MlpManager):
             model_type = "Artificial Neural Network (Multi-layer Perceptron)"
         elif isinstance(inputs_model, WoeManager):
@@ -96,7 +108,10 @@ class Serializer():
             for factor_name, factor_content in inputs_factors.items():
                 try:
                     factors_metadata.append(
-                        {"name": factor_name, "bandcount": factor_content.bandcount}
+                        {
+                            "name": factor_name,
+                            "bandcount": factor_content.bandcount,
+                        }
                     )
                 except Exception as e:
                     raise SerializerError("Invalid factor. %s" % str(e)) from e
@@ -106,24 +121,29 @@ class Serializer():
         creation_ts = datetime.now()
         molusce_version = pluginMetadata("molusce", "version")
 
-        return cls(inputs_model,
-                   inputs_initial.getXSize(),
-                   inputs_initial.getYSize(),
-                   inputs_initial.getUniqueValues(),
-                   factors_metadata,
-                   model_type,
-                   creation_ts,
-                   molusce_version)
+        return cls(
+            inputs_model,
+            inputs_initial.getXSize(),
+            inputs_initial.getYSize(),
+            inputs_initial.getUniqueValues(),
+            factors_metadata,
+            model_type,
+            creation_ts,
+            molusce_version,
+        )
 
-    def to_file(self, file_path: str):
+    def to_file(self, file_path: str) -> None:
         with open(file_path, "wb") as f:
-            pickle.dump({
-                "model": self.model,
-                "base_xsize": self.base_xsize,
-                "base_ysize": self.base_ysize,
-                "base_classes": self.base_classes,
-                "factors_metadata": self.factors_metadata,
-                "model_type": self.model_type,
-                "creation_ts": self.creation_ts,
-                "molusce_version": self.molusce_version
-            }, f)
+            pickle.dump(
+                {
+                    "model": self.model,
+                    "base_xsize": self.base_xsize,
+                    "base_ysize": self.base_ysize,
+                    "base_classes": self.base_classes,
+                    "factors_metadata": self.factors_metadata,
+                    "model_type": self.model_type,
+                    "creation_ts": self.creation_ts,
+                    "molusce_version": self.molusce_version,
+                },
+                f,
+            )

--- a/src/molusce/algorithms/models/serializer/serializer.py
+++ b/src/molusce/algorithms/models/serializer/serializer.py
@@ -1,0 +1,129 @@
+import pickle
+from datetime import datetime
+
+from molusce.algorithms.dataprovider import Raster
+from molusce.algorithms.models.lr.lr import LR
+from molusce.algorithms.models.mce.mce import MCE
+from molusce.algorithms.models.mlp.manager import MlpManager
+from molusce.algorithms.models.woe.manager import WoeManager
+from qgis.utils import pluginMetadata
+
+
+class SerializerError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+class Serializer():
+    model = None
+    base_xsize = None
+    base_ysize = None
+    base_classes = None
+    factors_metadata = None
+    model_type = None
+    creation_ts = None
+    molusce_version = None
+
+    def __init__(self, model, base_xsize, base_ysize, base_classes, factors_metadata, model_type, creation_ts, molusce_version):
+        self.model = model
+        self.base_xsize = base_xsize
+        self.base_ysize = base_ysize
+        self.base_classes = base_classes
+        self.factors_metadata = factors_metadata
+        self.model_type = model_type
+        self.creation_ts = creation_ts
+        self.molusce_version = molusce_version
+
+    @classmethod
+    def from_file(cls, file_path: str):
+        try:
+            with open(file_path, "rb") as f:
+                imported_model = pickle.load(f)
+        except Exception as e:
+            raise SerializerError("Invalid file. %s" % str(e)) from e
+
+        if not all( 
+            k in imported_model
+            for k in (
+                "model",
+                "base_xsize",
+                "base_ysize",
+                "base_classes",
+                "factors_metadata",
+                "model_type",
+                "creation_ts",
+                "molusce_version",
+            )
+        ):
+            raise SerializerError("Invalid file")
+
+        if (
+            not isinstance(imported_model["model"], MlpManager)
+            and not isinstance(imported_model["model"], WoeManager)
+            and not isinstance(imported_model["model"], LR)
+            and not isinstance(imported_model["model"], MCE)
+        ):
+            raise SerializerError("Invalid model type")
+
+        return cls(imported_model["model"],
+                imported_model["base_xsize"],
+                imported_model["base_ysize"],
+                imported_model["base_classes"],
+                imported_model["factors_metadata"],
+                imported_model["model_type"],
+                imported_model["creation_ts"],
+                imported_model["molusce_version"])
+
+
+    @classmethod
+    def from_data(cls, inputs_model, inputs_initial, inputs_factors):
+
+        if isinstance(inputs_model, MlpManager):
+            model_type = "Artificial Neural Network (Multi-layer Perceptron)"
+        elif isinstance(inputs_model, WoeManager):
+            model_type = "Weights of Evidence"
+        elif isinstance(inputs_model, LR):
+            model_type = "Logistic Regression"
+        elif isinstance(inputs_model, MCE):
+            model_type = "Multi Criteria Evaluation"
+        else:
+            raise SerializerError("Model is unknown")
+
+        if not isinstance(inputs_initial, Raster):
+            raise SerializerError("Invalid initial raster")
+
+        factors_metadata = []
+        try:
+            for factor_name, factor_content in inputs_factors.items():
+                try:
+                    factors_metadata.append(
+                        {"name": factor_name, "bandcount": factor_content.bandcount}
+                    )
+                except Exception as e:
+                    raise SerializerError("Invalid factor. %s" % str(e)) from e
+        except Exception as e:
+            raise SerializerError("Invalid factors. %s" % str(e)) from e
+
+        creation_ts = datetime.now()
+        molusce_version = pluginMetadata("molusce", "version")
+
+        return cls(inputs_model,
+                   inputs_initial.getXSize(),
+                   inputs_initial.getYSize(),
+                   inputs_initial.getUniqueValues(),
+                   factors_metadata,
+                   model_type,
+                   creation_ts,
+                   molusce_version)
+
+    def to_file(self, file_path: str):
+        with open(file_path, "wb") as f:
+            pickle.dump({
+                "model": self.model,
+                "base_xsize": self.base_xsize,
+                "base_ysize": self.base_ysize,
+                "base_classes": self.base_classes,
+                "factors_metadata": self.factors_metadata,
+                "model_type": self.model_type,
+                "creation_ts": self.creation_ts,
+                "molusce_version": self.molusce_version
+            }, f)

--- a/src/molusce/algorithms/models/serializer/serializer.py
+++ b/src/molusce/algorithms/models/serializer/serializer.py
@@ -1,5 +1,7 @@
 import pickle
+from dataclasses import dataclass
 from datetime import datetime
+from typing import Dict, List, Set, Union
 
 from qgis.utils import pluginMetadata
 
@@ -15,80 +17,48 @@ class SerializerError(Exception):
         self.msg = msg
 
 
-class Serializer:
-    model = None
-    base_xsize = None
-    base_ysize = None
-    base_classes = None
-    factors_metadata = None
-    model_type = None
-    creation_ts = None
-    molusce_version = None
+@dataclass
+class ModelParams:
+    model_type: str
+    model: Union[MlpManager, WoeManager, LR, MCE]
+    base_xsize: int
+    base_ysize: int
+    base_classes: Set
+    factors_metadata: List[Dict[str, int]]
+    molusce_version: str
+    creation_ts: datetime
 
-    def __init__(
+    def is_consistent_with(
         self,
-        model,
-        base_xsize,
-        base_ysize,
-        base_classes,
-        factors_metadata,
-        model_type,
-        creation_ts,
-        molusce_version,
-    ):
-        self.model = model
-        self.base_xsize = base_xsize
-        self.base_ysize = base_ysize
-        self.base_classes = base_classes
-        self.factors_metadata = factors_metadata
-        self.model_type = model_type
-        self.creation_ts = creation_ts
-        self.molusce_version = molusce_version
+        inputs_initial: Raster,
+        inputs_factors: Dict[str, Raster],
+    ) -> bool:
+        if (self.base_xsize, self.base_ysize) != (
+            inputs_initial.getXSize(),
+            inputs_initial.getYSize(),
+        ):
+            return False
 
-    @classmethod
-    def from_file(cls, file_path: str):
-        try:
-            with open(file_path, "rb") as f:
-                imported_model = pickle.load(f)
-        except Exception as e:
-            raise SerializerError("Invalid file. %s" % str(e)) from e
+        if self.base_classes != inputs_initial.getUniqueValues():
+            return False
 
-        if not all(
-            k in imported_model
-            for k in (
-                "model",
-                "base_xsize",
-                "base_ysize",
-                "base_classes",
-                "factors_metadata",
-                "model_type",
-                "creation_ts",
-                "molusce_version",
+        if len(self.factors_metadata) != len(inputs_factors) or not all(
+            loaded_factor["bandcount"] == input_factor.bandcount
+            for loaded_factor, input_factor in zip(
+                self.factors_metadata, inputs_factors.values()
             )
         ):
-            raise SerializerError("Invalid file")
+            return False
 
-        if (
-            not isinstance(imported_model["model"], MlpManager)
-            and not isinstance(imported_model["model"], WoeManager)
-            and not isinstance(imported_model["model"], LR)
-            and not isinstance(imported_model["model"], MCE)
-        ):
-            raise SerializerError("Invalid model type")
-
-        return cls(
-            imported_model["model"],
-            imported_model["base_xsize"],
-            imported_model["base_ysize"],
-            imported_model["base_classes"],
-            imported_model["factors_metadata"],
-            imported_model["model_type"],
-            imported_model["creation_ts"],
-            imported_model["molusce_version"],
-        )
+        return True
 
     @classmethod
-    def from_data(cls, inputs_model, inputs_initial, inputs_factors):
+    def from_data(
+        cls,
+        inputs_model: Union[MlpManager, WoeManager, LR, MCE],
+        inputs_initial: Raster,
+        inputs_factors: Dict[str, Raster],
+    ) -> "ModelParams":
         if isinstance(inputs_model, MlpManager):
             model_type = "Artificial Neural Network (Multi-layer Perceptron)"
         elif isinstance(inputs_model, WoeManager):
@@ -113,37 +83,51 @@ class Serializer:
                             "bandcount": factor_content.bandcount,
                         }
                     )
-                except Exception as e:
-                    raise SerializerError("Invalid factor. %s" % str(e)) from e
-        except Exception as e:
-            raise SerializerError("Invalid factors. %s" % str(e)) from e
+                except Exception as error:
+                    raise SerializerError(
+                        "Invalid factor. %s" % str(error)
+                    ) from error
 
-        creation_ts = datetime.now()
-        molusce_version = pluginMetadata("molusce", "version")
+        except Exception as error:
+            raise SerializerError(
+                "Invalid factors. %s" % str(error)
+            ) from error
 
-        return cls(
+        return ModelParams(
+            model_type,
             inputs_model,
             inputs_initial.getXSize(),
             inputs_initial.getYSize(),
             inputs_initial.getUniqueValues(),
             factors_metadata,
-            model_type,
-            creation_ts,
-            molusce_version,
+            molusce_version=pluginMetadata("molusce", "version"),
+            creation_ts=datetime.now(),
         )
 
-    def to_file(self, file_path: str) -> None:
-        with open(file_path, "wb") as f:
-            pickle.dump(
-                {
-                    "model": self.model,
-                    "base_xsize": self.base_xsize,
-                    "base_ysize": self.base_ysize,
-                    "base_classes": self.base_classes,
-                    "factors_metadata": self.factors_metadata,
-                    "model_type": self.model_type,
-                    "creation_ts": self.creation_ts,
-                    "molusce_version": self.molusce_version,
-                },
-                f,
-            )
+
+class ModelParamsSerializer:
+    @classmethod
+    def from_file(cls, file_path: str) -> ModelParams:
+        try:
+            with open(file_path, "rb") as file:
+                model_params: ModelParams = pickle.load(file)
+        except Exception as error:
+            raise SerializerError("Invalid file. %s" % str(error)) from error
+
+        if not isinstance(
+            model_params.model, (MlpManager, WoeManager, LR, MCE)
+        ):
+            raise SerializerError("Invalid model type")
+
+        return model_params
+
+    @classmethod
+    def to_file(cls, model_params: ModelParams, file_path: str) -> None:
+        try:
+            with open(file_path, "wb") as file:
+                pickle.dump(model_params, file)
+
+        except Exception as error:
+            raise SerializerError(
+                "An error occurred while writing data"
+            ) from error

--- a/src/molusce/algorithms/models/simulator/sim.py
+++ b/src/molusce/algorithms/models/simulator/sim.py
@@ -13,7 +13,7 @@ class Simulator(QObject):
     over a number of cycles
     """
 
-    rangeChanged = pyqtSignal(str, int) 
+    rangeChanged = pyqtSignal(str, int)
     updateProgress = pyqtSignal()
     simFinished = pyqtSignal()
     logMessage = pyqtSignal(str)

--- a/src/molusce/algorithms/models/woe/manager.py
+++ b/src/molusce/algorithms/models/woe/manager.py
@@ -317,9 +317,9 @@ class WoeManager(QObject):
                 ).format(code, initClass, finalClass)
                 raise
         return text
-    
+
     # Make WoeManager class available for pickle
-    def __getstate__(self)->dict:
+    def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         return state
 

--- a/src/molusce/algorithms/models/woe/manager.py
+++ b/src/molusce/algorithms/models/woe/manager.py
@@ -52,7 +52,7 @@ class WoeManager(QObject):
                                 List of list used because a factor can be a multiband raster, we need get a list of bins for every band. For example:
                                 factors = [f0, 2-band-factor], bins= {0: [[10, 100, 250]], 1:[[0.2, 1, 1.5, 4], [3, 4, 7]] }
         """
-        QObject.__init__(self)
+        super().__init__()
 
         self.factors = factors
         self.analyst = areaAnalyst
@@ -317,3 +317,12 @@ class WoeManager(QObject):
                 ).format(code, initClass, finalClass)
                 raise
         return text
+    
+    # Make WoeManager class available for pickle
+    def __getstate__(self)->dict:
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state: dict):
+        self.__dict__.update(state)
+        QObject.__init__(self)

--- a/src/molusce/algorithms/models/woe/manager.py
+++ b/src/molusce/algorithms/models/woe/manager.py
@@ -7,6 +7,7 @@ from qgis.PyQt.QtCore import *
 from molusce.algorithms.dataprovider import Raster
 from molusce.algorithms.models.woe.model import WoeError
 from molusce.algorithms.utils import binaryzation, masks_identity, reclass
+from molusce.molusceutils import PickleQObjectMixin
 
 from .model import woe
 
@@ -32,7 +33,7 @@ class WoeManagerError(Exception):
         self.msg = msg
 
 
-class WoeManager(QObject):
+class WoeManager(PickleQObjectMixin, QObject):
     """This class gets the data extracted from the UI and
     pass it to woe function, then gets and stores the result.
     """
@@ -317,12 +318,3 @@ class WoeManager(QObject):
                 ).format(code, initClass, finalClass)
                 raise
         return text
-
-    # Make WoeManager class available for pickle
-    def __getstate__(self) -> dict:
-        state = self.__dict__.copy()
-        return state
-
-    def __setstate__(self, state: dict):
-        self.__dict__.update(state)
-        QObject.__init__(self)

--- a/src/molusce/loadedmodelwidget.py
+++ b/src/molusce/loadedmodelwidget.py
@@ -33,9 +33,7 @@ from .ui.ui_loadedmodelwidgetbase import (
 )
 
 
-class LoadedModelWidget(
-    QWidget, Ui_LoadedModelWidgetBase
-):
+class LoadedModelWidget(QWidget, Ui_LoadedModelWidgetBase):
     def __init__(self, plugin, parent=None):
         QWidget.__init__(self, parent)
         self.setupUi(self)

--- a/src/molusce/loadedmodelwidget.py
+++ b/src/molusce/loadedmodelwidget.py
@@ -1,0 +1,46 @@
+# ******************************************************************************
+#
+# MOLUSCE
+# ---------------------------------------------------------
+# Modules for Land Use Change Simulations
+#
+# Copyright (C) 2012-2013 NextGIS (info@nextgis.org)
+#
+# This source is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 2 of the License, or (at your option)
+# any later version.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# A copy of the GNU General Public License is available on the World Wide Web
+# at <http://www.gnu.org/licenses/>. You can also obtain it by writing
+# to the Free Software Foundation, 51 Franklin Street, Suite 500 Boston,
+# MA 02110-1335 USA.
+#
+# ******************************************************************************
+
+from qgis.core import *
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtGui import *
+from qgis.PyQt.QtWidgets import *
+
+from .ui.ui_loadedmodelwidgetbase import (
+    Ui_LoadedModelWidgetBase,
+)
+
+
+class LoadedModelWidget(
+    QWidget, Ui_LoadedModelWidgetBase
+):
+    def __init__(self, plugin, parent=None):
+        QWidget.__init__(self, parent)
+        self.setupUi(self)
+
+        self.plugin = plugin
+        self.inputs = plugin.inputs
+
+        self.settings = QSettings("NextGIS", "MOLUSCE")

--- a/src/molusce/moluscedialog.py
+++ b/src/molusce/moluscedialog.py
@@ -625,20 +625,30 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         if not utils.checkFactors(self.inputs):
             return False
 
-        if not (imported_model['base_xsize'] == self.inputs["initial"].getXSize()) or not (imported_model['base_ysize'] == self.inputs["initial"].getYSize()):
+        if not (
+            imported_model["base_xsize"] == self.inputs["initial"].getXSize()
+        ) or not (
+            imported_model["base_ysize"] == self.inputs["initial"].getYSize()
+        ):
             return False
 
-        if not imported_model['base_classes'] == self.inputs["initial"].getUniqueValues():
+        if (
+            not imported_model["base_classes"]
+            == self.inputs["initial"].getUniqueValues()
+        ):
             return False
 
-        if len(imported_model["factors_metadata"]) != len(self.inputs["factors"]):
+        if len(imported_model["factors_metadata"]) != len(
+            self.inputs["factors"]
+        ):
             return False
-        for input_factor, loaded_factor in zip(self.inputs["factors"].values(), imported_model["factors_metadata"]):
-            if input_factor.bandcount != loaded_factor['bandcount']:
+        for input_factor, loaded_factor in zip(
+            self.inputs["factors"].values(), imported_model["factors_metadata"]
+        ):
+            if input_factor.bandcount != loaded_factor["bandcount"]:
                 return False
 
         return True
-
 
     def checkConsistencySeparateVars(self) -> None:
         # separate spatial variables for simulations should be:
@@ -1038,7 +1048,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             QMessageBox.warning(
                 self,
                 self.tr("Missed model"),
-                self.tr("Model not selected. Please select and train model.")
+                self.tr("Model not selected. Please select and train model."),
             )
 
         if is_risk_function_path_unlinking:
@@ -1568,11 +1578,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         if not scipyMissed:
             self.cmbSimulationMethod.addItem(self.tr("Logistic Regression"))
 
-        self.cmbSimulationMethod.addItems(
-            [
-                self.tr("Model from file")
-            ]
-        )
+        self.cmbSimulationMethod.addItems([self.tr("Model from file")])
 
     def __populateSamplingModes(self):
         self.cmbSamplingMode.addItem(self.tr("All"), 0)
@@ -2004,11 +2010,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             )
             self.grpSampling.hide()
         elif modelName == self.tr("Model from file"):
-            self.modelWidget = (
-                loadedmodelwidget.LoadedModelWidget(
-                    self
-                )
-            )
+            self.modelWidget = loadedmodelwidget.LoadedModelWidget(self)
             self.grpSampling.hide()
 
         self.widgetStackMethods.addWidget(self.modelWidget)
@@ -2448,7 +2450,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         return ""
 
     def saveModel(self) -> None:
-        if not ("model" in self.inputs):
+        if "model" not in self.inputs:
             QMessageBox.warning(
                 self,
                 self.tr("Model is missed"),
@@ -2461,7 +2463,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             self.settings,
             self.tr("Save MOLUSCE model"),
             self.tr("MOLUSCE (*.molusce *.MOLUSCE)"),
-            "molusce"
+            "molusce",
         )
 
         if not file_name:
@@ -2479,7 +2481,9 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             QMessageBox.warning(
                 self,
                 self.tr("Model is unknown"),
-                self.tr("Model is currently not supported by save/load mechanism"),
+                self.tr(
+                    "Model is currently not supported by save/load mechanism"
+                ),
             )
             return
 
@@ -2491,14 +2495,13 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             "factors_metadata": [],
             "model_type": model_type,
             "creation_ts": datetime.datetime.now(),
-            "molusce_version": pluginMetadata("molusce", "version")
+            "molusce_version": pluginMetadata("molusce", "version"),
         }
 
         for factor_name, factor_content in self.inputs["factors"].items():
-            model_for_export["factors_metadata"].append({
-                "name": factor_name,
-                "bandcount": factor_content.bandcount
-            })
+            model_for_export["factors_metadata"].append(
+                {"name": factor_name, "bandcount": factor_content.bandcount}
+            )
 
         try:
             with open(file_name, "wb") as f:
@@ -2507,7 +2510,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
                     self,
                     self.tr("Model saved"),
                     self.tr("Model was succesfully saved"),
-            )
+                )
             return
         except Exception as e:
             QMessageBox.warning(
@@ -2538,7 +2541,19 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             )
             return
 
-        if not all(k in imported_model for k in ("model","base_xsize","base_ysize","base_classes","factors_metadata","model_type","creation_ts","molusce_version")):
+        if not all(
+            k in imported_model
+            for k in (
+                "model",
+                "base_xsize",
+                "base_ysize",
+                "base_classes",
+                "factors_metadata",
+                "model_type",
+                "creation_ts",
+                "molusce_version",
+            )
+        ):
             QMessageBox.warning(
                 self,
                 self.tr("Invalid model"),
@@ -2546,10 +2561,12 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             )
             return
 
-        if not isinstance(imported_model["model"], MlpManager) and \
-            not isinstance(imported_model["model"], WoeManager) and \
-                not isinstance(imported_model["model"], LR) and \
-                    not isinstance(imported_model["model"], MCE):
+        if (
+            not isinstance(imported_model["model"], MlpManager)
+            and not isinstance(imported_model["model"], WoeManager)
+            and not isinstance(imported_model["model"], LR)
+            and not isinstance(imported_model["model"], MCE)
+        ):
             QMessageBox.warning(
                 self,
                 self.tr("Invalid model"),
@@ -2559,33 +2576,109 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
 
         consistency = self.checkConsistencyLoadedModel(imported_model)
 
-        index = self.cmbSimulationMethod.findText(self.tr("Model from file"), Qt.MatchFlag.MatchFixedString)
+        index = self.cmbSimulationMethod.findText(
+            self.tr("Model from file"), Qt.MatchFlag.MatchFixedString
+        )
         self.cmbSimulationMethod.setCurrentIndex(index)
 
         self.modelWidget.loadedModelTextEdit.clear()
-        self.modelWidget.loadedModelTextEdit.append(self.tr("<font color=\"black\">Model is loaded. Configuration:</font>\n"))
-        self.modelWidget.loadedModelTextEdit.append(self.tr("Model type: {}\n".format(imported_model["model_type"])))
-        self.modelWidget.loadedModelTextEdit.append(self.tr("Creation date: {}\n".format(imported_model["creation_ts"])))
-        self.modelWidget.loadedModelTextEdit.append(self.tr("MOLUSCE version: {}\n".format(imported_model["molusce_version"])))
-        if pluginMetadata("molusce", "version") != imported_model["molusce_version"]:
-            self.modelWidget.loadedModelTextEdit.append(self.tr("<font color=\"red\">[WARNING!] Model was created in different MOLUSCE version ({})</font>\n".format(imported_model["molusce_version"])))
-        self.modelWidget.loadedModelTextEdit.append(self.tr("Spatial domain dimensions: {}x{}\n".format(imported_model["base_xsize"], imported_model["base_ysize"])))
-        self.modelWidget.loadedModelTextEdit.append(self.tr("Classes: {}\n".format(imported_model["base_classes"])))
-        self.modelWidget.loadedModelTextEdit.append(self.tr("List of factors used for training:\n"))
+        self.modelWidget.loadedModelTextEdit.append(
+            self.tr(
+                '<font color="black">Model is loaded. Configuration:</font>\n'
+            )
+        )
+        self.modelWidget.loadedModelTextEdit.append(
+            self.tr("Model type: {}\n".format(imported_model["model_type"]))
+        )
+        self.modelWidget.loadedModelTextEdit.append(
+            self.tr(
+                "Creation date: {}\n".format(imported_model["creation_ts"])
+            )
+        )
+        self.modelWidget.loadedModelTextEdit.append(
+            self.tr(
+                "MOLUSCE version: {}\n".format(
+                    imported_model["molusce_version"]
+                )
+            )
+        )
+        if (
+            pluginMetadata("molusce", "version")
+            != imported_model["molusce_version"]
+        ):
+            self.modelWidget.loadedModelTextEdit.append(
+                self.tr(
+                    '<font color="red">[WARNING!] Model was created in different MOLUSCE version ({})</font>\n'.format(
+                        imported_model["molusce_version"]
+                    )
+                )
+            )
+        self.modelWidget.loadedModelTextEdit.append(
+            self.tr(
+                "Spatial domain dimensions: {}x{}\n".format(
+                    imported_model["base_xsize"], imported_model["base_ysize"]
+                )
+            )
+        )
+        self.modelWidget.loadedModelTextEdit.append(
+            self.tr("Classes: {}\n".format(imported_model["base_classes"]))
+        )
+        self.modelWidget.loadedModelTextEdit.append(
+            self.tr("List of factors used for training:\n")
+        )
         for factor in imported_model["factors_metadata"]:
-            self.modelWidget.loadedModelTextEdit.append(self.tr("  * {} ({} bands)\n".format(factor["name"],factor["bandcount"])))
+            self.modelWidget.loadedModelTextEdit.append(
+                self.tr(
+                    "  * {} ({} bands)\n".format(
+                        factor["name"], factor["bandcount"]
+                    )
+                )
+            )
         if consistency:
             self.inputs["model"] = imported_model["model"]
-            self.modelWidget.loadedModelTextEdit.append(self.tr("<font color=\"green\">[SUCCESS!] Model is compatible with current inputs setup. Successfully loaded</font>"))
+            self.modelWidget.loadedModelTextEdit.append(
+                self.tr(
+                    '<font color="green">[SUCCESS!] Model is compatible with current inputs setup. Successfully loaded</font>'
+                )
+            )
         else:
-            self.modelWidget.loadedModelTextEdit.append(self.tr("<font color=\"red\">[WARNING!] Model is incompatible with current inputs setup. Impossible to use</font>"))
-            self.modelWidget.loadedModelTextEdit.append(self.tr("\n=======================\n"))
-            self.modelWidget.loadedModelTextEdit.append(self.tr("Current inputs setup:\n"))
-            self.modelWidget.loadedModelTextEdit.append(self.tr("Spatial domain dimensions: {}x{}\n".format(self.inputs["initial"].getXSize(), self.inputs["initial"].getYSize())))
-            self.modelWidget.loadedModelTextEdit.append(self.tr("Classes: {}\n".format(self.inputs["initial"].getUniqueValues())))
-            self.modelWidget.loadedModelTextEdit.append(self.tr("List of factors used for training:\n"))
+            self.modelWidget.loadedModelTextEdit.append(
+                self.tr(
+                    '<font color="red">[WARNING!] Model is incompatible with current inputs setup. Impossible to use</font>'
+                )
+            )
+            self.modelWidget.loadedModelTextEdit.append(
+                self.tr("\n=======================\n")
+            )
+            self.modelWidget.loadedModelTextEdit.append(
+                self.tr("Current inputs setup:\n")
+            )
+            self.modelWidget.loadedModelTextEdit.append(
+                self.tr(
+                    "Spatial domain dimensions: {}x{}\n".format(
+                        self.inputs["initial"].getXSize(),
+                        self.inputs["initial"].getYSize(),
+                    )
+                )
+            )
+            self.modelWidget.loadedModelTextEdit.append(
+                self.tr(
+                    "Classes: {}\n".format(
+                        self.inputs["initial"].getUniqueValues()
+                    )
+                )
+            )
+            self.modelWidget.loadedModelTextEdit.append(
+                self.tr("List of factors used for training:\n")
+            )
             for factor_name, factor_content in self.inputs["factors"].items():
-                self.modelWidget.loadedModelTextEdit.append(self.tr("  * {} ({} bands)\n".format(factor_name, factor_content.bandcount)))
+                self.modelWidget.loadedModelTextEdit.append(
+                    self.tr(
+                        "  * {} ({} bands)\n".format(
+                            factor_name, factor_content.bandcount
+                        )
+                    )
+                )
 
     def __checking_file_saving(self, filepath):
         parent_path = filepath.parent

--- a/src/molusce/moluscedialog.py
+++ b/src/molusce/moluscedialog.py
@@ -50,7 +50,6 @@ except ImportError:
         NavigationToolbar2QT as NavigationToolbar,
     )
 
-import pickle
 from importlib.util import find_spec
 
 from matplotlib.figure import Figure
@@ -75,15 +74,13 @@ from .algorithms.models.crosstabs.manager import (
 )
 from .algorithms.models.crosstabs.model import CrossTabError
 from .algorithms.models.errorbudget.ebmodel import EBError, EBudget
-from .algorithms.models.lr.lr import LR
-from .algorithms.models.mce.mce import MCE
-from .algorithms.models.mlp.manager import MlpManager
 from .algorithms.models.sampler.sampler import SamplerError
+from .algorithms.models.serializer.serializer import (
+    Serializer,
+    SerializerError,
+)
 from .algorithms.models.simulator.sim import Simulator
-from .algorithms.models.woe.manager import WoeManager
 from .ui.ui_moluscedialogbase import Ui_MolusceDialogBase
-from .algorithms.models.serializer.serializer import Serializer, SerializerError
-
 
 scipyMissed = False
 if find_spec("scipy") is not None:
@@ -623,7 +620,9 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
         self.geometry_matched = True
         self.__updateAnalyticTabs(self.geometry_matched)
 
-    def checkConsistencyLoadedModel(self, serialized_model: Serializer) -> bool:
+    def checkConsistencyLoadedModel(
+        self, serialized_model: Serializer
+    ) -> bool:
         if not utils.checkFactors(self.inputs):
             return False
 
@@ -2472,28 +2471,26 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             return
 
         try:
-            serialized_model = Serializer.from_data(self.inputs["model"],
-                                                    self.inputs["initial"],
-                                                    self.inputs["factors"])
+            serialized_model = Serializer.from_data(
+                self.inputs["model"],
+                self.inputs["initial"],
+                self.inputs["factors"],
+            )
         except SerializerError as e:
             QMessageBox.warning(
                 self,
                 self.tr("Error"),
-                self.tr(
-                    "Serialization error: %s" % str(e)
-                ),
+                self.tr("Serialization error: %s" % str(e)),
             )
             return
         except Exception as e:
             QMessageBox.warning(
                 self,
                 self.tr("Error"),
-                self.tr(
-                    "Unknown error: %s" % str(e)
-                ),
+                self.tr("Unknown error: %s" % str(e)),
             )
             return
-        
+
         try:
             serialized_model.to_file(file_name)
         except Exception as e:
@@ -2503,12 +2500,12 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
                 self.tr("Error: %s" % str(e)),
             )
             return
-        
+
         QMessageBox.warning(
-                self,
-                self.tr("Success!"),
-                self.tr("Model was succesfully saved"),
-            )
+            self,
+            self.tr("Success!"),
+            self.tr("Model was succesfully saved"),
+        )
 
     def loadModel(self) -> None:
         file_name = utils.openRasterDialog(
@@ -2526,18 +2523,14 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             QMessageBox.warning(
                 self,
                 self.tr("Error"),
-                self.tr(
-                    "Serialization error: %s" % str(e)
-                ),
+                self.tr("Serialization error: %s" % str(e)),
             )
             return
         except Exception as e:
             QMessageBox.warning(
                 self,
                 self.tr("Error"),
-                self.tr(
-                    "Unknown error: %s" % str(e)
-                ),
+                self.tr("Unknown error: %s" % str(e)),
             )
             return
 
@@ -2558,9 +2551,7 @@ class MolusceDialog(QDialog, Ui_MolusceDialogBase):
             self.tr("Model type: {}\n".format(serialized_model.model_type))
         )
         self.modelWidget.loadedModelTextEdit.append(
-            self.tr(
-                "Creation date: {}\n".format(serialized_model.creation_ts)
-            )
+            self.tr("Creation date: {}\n".format(serialized_model.creation_ts))
         )
         self.modelWidget.loadedModelTextEdit.append(
             self.tr(

--- a/src/molusce/molusceutils.py
+++ b/src/molusce/molusceutils.py
@@ -199,8 +199,7 @@ def checkInputRasters(userData):
 def checkFactors(userData, sim=False):
     if not sim:
         return "factors" in userData
-    else:
-        return "factors_sim" in userData
+    return "factors_sim" in userData
 
 
 def checkChangeMap(userData):

--- a/src/molusce/ui/loadedmodelwidgetbase.ui
+++ b/src/molusce/ui/loadedmodelwidgetbase.ui
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LoadedModelWidgetBase</class>
+ <widget class="QWidget" name="LoadedModelWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>684</width>
+    <height>368</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QTextEdit" name="loadedModelTextEdit">
+     <property name="undoRedoEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="html">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Model is not loaded&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/molusce/ui/moluscedialogbase.ui
+++ b/src/molusce/ui/moluscedialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>887</width>
-    <height>792</height>
+    <width>894</width>
+    <height>756</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
       <bool>true</bool>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="tabInputs">
       <attribute name="title">
@@ -285,14 +285,17 @@
        <string>Transition Potential Modelling</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_3">
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>Method</string>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="cmbSimulationMethod">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
         </widget>
        </item>
-       <item row="0" column="0" colspan="3">
+       <item row="0" column="0" colspan="4">
         <widget class="QgsCollapsibleGroupBox" name="grpSampling">
          <property name="title">
           <string>Define Samples</string>
@@ -357,30 +360,7 @@
          </layout>
         </widget>
        </item>
-       <item row="2" column="1">
-        <widget class="QComboBox" name="cmbSimulationMethod">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="3" column="0" colspan="3">
+       <item row="5" column="0" colspan="6">
         <widget class="QStackedWidget" name="widgetStackMethods">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -398,6 +378,64 @@
           <number>-1</number>
          </property>
         </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Method</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="3">
+        <widget class="QPushButton" name="saveModelBtn">
+         <property name="minimumSize">
+          <size>
+           <width>140</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>200</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Save current model to file</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="4">
+        <widget class="QPushButton" name="loadModelBtn">
+         <property name="minimumSize">
+          <size>
+           <width>140</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>200</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Load model from file</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>

--- a/src/molusce/weightofevidencewidget.py
+++ b/src/molusce/weightofevidencewidget.py
@@ -86,9 +86,7 @@ class WeightOfEvidenceWidget(QWidget, Ui_WeightOfEvidenceWidgetBase):
                 if v.isCountinues(b):
                     self.tblReclass.insertRow(row)
                     if v.getBandsCount() > 1:
-                        name = (
-                            f"{utils.getLayerById(k).name()} (band {str(b+1)})"
-                        )
+                        name = f"{utils.getLayerById(k).name()} (band {str(b + 1)})"
                     else:
                         name = utils.getLayerById(k).name()
                     stat = v.getBandStat(b)
@@ -195,9 +193,7 @@ class WeightOfEvidenceWidget(QWidget, Ui_WeightOfEvidenceWidgetBase):
                 lst.append(None)
                 if v.isCountinues(b + 1):
                     if v.getBandsCount() > 1:
-                        name = (
-                            f"{utils.getLayerById(k).name()} (band {str(b+1)})"
-                        )
+                        name = f"{utils.getLayerById(k).name()} (band {str(b + 1)})"
                     else:
                         name = utils.getLayerById(k).name()
                     items = self.tblReclass.findItems(name, Qt.MatchExactly)

--- a/tests/models/mce/test_mce.py
+++ b/tests/models/mce/test_mce.py
@@ -1,5 +1,10 @@
 import unittest
+from datetime import datetime
 from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import cast
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import numpy as np
 from numpy.testing import assert_almost_equal
@@ -7,6 +12,10 @@ from numpy.testing import assert_almost_equal
 from molusce.algorithms.dataprovider import Raster
 from molusce.algorithms.models.area_analysis.manager import AreaAnalyst
 from molusce.algorithms.models.mce.mce import MCE
+from molusce.algorithms.models.serializer.serializer import (
+    ModelParams,
+    ModelParamsSerializer,
+)
 
 
 class TestMCE(unittest.TestCase):
@@ -78,6 +87,78 @@ class TestMCE(unittest.TestCase):
         ]
         answer = np.ma.array(data=answer, mask=mask)
         assert_almost_equal(c, answer)
+
+    @patch("molusce.algorithms.models.serializer.serializer.pluginMetadata")
+    @patch("molusce.algorithms.models.serializer.serializer.datetime")
+    def test_serialization(
+        self, datetime_mock: MagicMock, metadata_mock: MagicMock
+    ) -> None:
+        MOLUSCE_VERSION = "5.0.0"
+        metadata_mock.return_value = MOLUSCE_VERSION
+
+        FIXED_DATETIME = datetime(2006, 5, 4, 3, 2, 1)
+        datetime_mock.now.return_value = FIXED_DATETIME
+
+        data = [
+            [1.0, 4.0, 6.0, 7.0],
+            [1.0 / 4, 1.0, 3.0, 4.0],
+            [1.0 / 6, 1.0 / 3, 1.0, 2.0],
+            [1.0 / 7, 1.0 / 4, 1.0 / 2, 1],
+        ]
+        mce = MCE(
+            [self.factor, self.factor, self.factor, self.factor],
+            data,
+            1,
+            2,
+            self.areaAnalyst,
+        )
+
+        factors = {str(uuid4()): factor for factor in [self.factor]}
+        model_params = ModelParams.from_data(mce, self.state, factors)
+
+        with NamedTemporaryFile(delete=True) as temp_file:
+            ModelParamsSerializer.to_file(model_params, temp_file.name)
+            loaded_params = ModelParamsSerializer.from_file(temp_file.name)
+
+        self.assertTrue(
+            model_params.model_type
+            == loaded_params.model_type
+            == "Multi Criteria Evaluation"
+        )
+        self.assertTrue(isinstance(loaded_params.model, MCE))
+        self.assertTrue(
+            (model_params.base_xsize, model_params.base_ysize)
+            == (loaded_params.base_xsize, loaded_params.base_ysize)
+            == (self.state.getXSize(), self.state.getYSize())
+        )
+        self.assertTrue(
+            model_params.base_classes
+            == loaded_params.base_classes
+            == self.state.getUniqueValues()
+        )
+        self.assertTrue(
+            model_params.factors_metadata
+            == loaded_params.factors_metadata
+            == [
+                {"name": uuid, "bandcount": bandcount.bandcount}
+                for uuid, bandcount in factors.items()
+            ]
+        )
+        self.assertTrue(
+            model_params.molusce_version
+            == loaded_params.molusce_version
+            == MOLUSCE_VERSION
+        )
+        self.assertTrue(
+            model_params.creation_ts
+            == loaded_params.creation_ts
+            == FIXED_DATETIME
+        )
+
+        # Check model
+        weights = cast("MCE", loaded_params.model).getWeights()
+        answer = [0.61682294, 0.22382863, 0.09723423, 0.06211421]
+        assert_almost_equal(weights, answer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR offers new mechanics - saving and loading trained MOLUSCE models for better experimenting, especially in context of using separate spatial variables set for predicting step. Users could return back to trained model and try it with different variables version.

Model could be loaded and used, if:
- Current setup has same number of factors (and bands inside of them)
- Current setup has same spatial dimensions (rows and cols in initial rasters)

Pickle is used for saving the models.

New buttons on TPM tab:
![image](https://github.com/user-attachments/assets/1bf26515-f944-40ec-ab02-708774092a42)

Model loading interface if model is compatible:
![image](https://github.com/user-attachments/assets/65693a12-8e84-407d-90a5-a4baeec0bea2)

Model loading interface if model is not compatible:
![image](https://github.com/user-attachments/assets/4997ec5a-5712-41bb-967d-07d17e8262a6)
